### PR TITLE
Migrate Ditto secrets to .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copy this file from ".env.sample" to ".env", then fill in these values
+# A Ditto AppID and Playground token can be obtained from https://portal.ditto.live
+DITTO_APP_ID=""
+DITTO_PLAYGROUND_TOKEN=""
+DITTO_AUTH_URL=""
+DITTO_WEBSOCKET_URL=""

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Ditto environment secrets
+.env
+Env.swift

--- a/DrawTogether/DrawTogether.xcodeproj/project.pbxproj
+++ b/DrawTogether/DrawTogether.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A4A6DA4A2E873258001228BF /* Build configuration list for PBXNativeTarget "DrawTogether" */;
 			buildPhases = (
+				A4A6DA602E873500001228BF /* Generate Env.swift from .env */,
 				A4A6DA382E873256001228BF /* Sources */,
 				A4A6DA392E873256001228BF /* Frameworks */,
 				A4A6DA3A2E873256001228BF /* Resources */,
@@ -126,6 +127,26 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		A4A6DA602E873500001228BF /* Generate Env.swift from .env */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../.env",
+				"$(SRCROOT)/buildEnv.sh",
+			);
+			name = "Generate Env.swift from .env";
+			outputPaths = (
+				"$(SRCROOT)/DrawTogether/Env.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/buildEnv.sh\" \"$SRCROOT/../.env\" \"$SRCROOT/DrawTogether\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		A4A6DA382E873256001228BF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -174,7 +195,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -237,7 +258,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/DrawTogether/DrawTogether/DittoManager.swift
+++ b/DrawTogether/DrawTogether/DittoManager.swift
@@ -13,8 +13,8 @@ final class DittoManager {
     public let ditto: Ditto?
 
     private init() throws {
-        let cloudURL = URL(string: "YOUR_BIG_PEER_URL")!
-        let config = DittoConfig(databaseID: "YOUR_APP_ID", connect: .server(url: cloudURL))
+        let cloudURL = URL(string: Env.DITTO_WEBSOCKET_URL)!
+        let config = DittoConfig(databaseID: Env.DITTO_APP_ID, connect: .server(url: cloudURL))
         let ditto = try Ditto.openSync(config: config)
         try ditto.disableSyncWithV3()
         Task {

--- a/DrawTogether/buildEnv.sh
+++ b/DrawTogether/buildEnv.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+code=$(cat <<EOS
+
+import Foundation
+
+// This file is auto generated. Do not edit this, and edit .env instead.
+
+struct Env {
+
+EOS
+)
+
+if [ $# -ne 2 ]; then
+  echo "require 2 arguments." 1>&2
+  echo "./buildEnv.sh /path/to/.env /output/path" 1>&2
+  exit 1
+fi
+
+if [ -f "$1" ]; then
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+        line="${line//[$'\r\n']}"
+        trimline="${line//[$'\t\r\n ']}"
+        if [ -n "$trimline" ] && [[ $trimline != \#* ]]; then
+            KEY="${line%%=*}"
+            VALUE="$(echo "${line#*=}" | sed 's/^[[:space:]]*//; s/^"//; s/"$//')"
+            code=$(cat <<EOS
+        $code
+    static let $KEY = "$VALUE"
+EOS
+)
+        fi
+    done < "$1"
+fi
+
+code=$(cat <<EOS
+$code
+}
+EOS
+)
+
+echo "${code}" > "$2/Env.swift"
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds a `buildEnv.sh` build-phase script that reads a local `.env` file and generates an `Env.swift` struct at build time, following the [Ditto quickstart](https://github.com/getditto/quickstart) pattern
- Updates `DittoManager.swift` to reference `Env.DITTO_APP_ID` and `Env.DITTO_WEBSOCKET_URL` instead of hardcoded placeholder strings
- Gitignores `.env` and `Env.swift`; provides `.env.sample` for onboarding

Closes #3