### PR TITLE
Sync bitmap eraser strokes

### DIFF
--- a/DrawTogether/DrawTogether.xcodeproj/project.pbxproj
+++ b/DrawTogether/DrawTogether.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A451961A2F7AB38B0066566B /* DittoObjC in Frameworks */ = {isa = PBXBuildFile; productRef = A4A6DA512E873476001228BF /* DittoObjC */; };
+		A451961B2F7AB38B0066566B /* DittoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A4A6DA532E873476001228BF /* DittoSwift */; };
 		A4A6DA522E873476001228BF /* DittoObjC in Frameworks */ = {isa = PBXBuildFile; productRef = A4A6DA512E873476001228BF /* DittoObjC */; };
 		A4A6DA542E873476001228BF /* DittoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A4A6DA532E873476001228BF /* DittoSwift */; };
 /* End PBXBuildFile section */
@@ -53,6 +55,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A451961A2F7AB38B0066566B /* DittoObjC in Frameworks */,
+				A451961B2F7AB38B0066566B /* DittoSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DrawTogether/DrawTogether/DittoDrawingModel.swift
+++ b/DrawTogether/DrawTogether/DittoDrawingModel.swift
@@ -13,7 +13,7 @@ import PencilKit
 struct DittoDrawingModel {
     let drawingID: String
 
-    /// Maps Ditto key (ISO8601 timestamp string) to encoded single-stroke PKDrawing
+    /// Maps Ditto key (ISO8601 timestamp string) to encoded PKDrawing (may contain multiple strokes)
     private(set) var strokeMap: [String: String] = [:]
 
     /// Maps stroke creation date to Ditto key, for key reuse and remove detection
@@ -22,10 +22,10 @@ struct DittoDrawingModel {
     /// Reverse map: Ditto key to creation date, for O(1) removal lookups
     private(set) var keyToCreationDate: [String: Date] = [:]
 
-    /// Mask fingerprints for known strokes, used to detect bitmap eraser modifications.
-    /// Key is the Ditto key; value is NSKeyedArchiver data of the UIBezierPath mask.
-    /// Absent entry means the stroke has no mask.
-    private(set) var maskFingerprints: [String: Data] = [:]
+    /// Group fingerprints for known stroke groups, used to detect bitmap eraser modifications
+    /// (mask changes and stroke splits). Key is the Ditto key; value is a composite fingerprint
+    /// encoding stroke count and each stroke's mask data.
+    private(set) var groupFingerprints: [String: Data] = [:]
 
     init(drawingID: String = "1") {
         self.drawingID = drawingID
@@ -33,19 +33,20 @@ struct DittoDrawingModel {
 
     // MARK: - Drawing Reconstruction
 
-    /// Rebuilds a PKDrawing from strokeMap by sorting keys lexicographically (chronological z-order)
+    /// Rebuilds a PKDrawing from strokeMap by sorting keys lexicographically (chronological z-order).
+    /// Each key may contain multiple strokes (split pieces), which are flattened in order.
     func drawing() -> PKDrawing {
         let sortedKeys = strokeMap.keys.sorted()
-        let strokes: [PKStroke] = sortedKeys.compactMap { key in
+        let strokes: [PKStroke] = sortedKeys.flatMap { key -> [PKStroke] in
             guard let encoded = strokeMap[key] else {
                 NSLog("DittoDrawingModel.drawing(): Missing data for stroke key: %@", key)
-                return nil
+                return []
             }
-            guard let stroke = DittoStrokeModel.decode(from: encoded) else {
-                NSLog("DittoDrawingModel.drawing(): Failed to decode stroke for key: %@", key)
-                return nil
+            let decoded = DittoStrokeModel.decodeGroup(from: encoded)
+            if decoded.isEmpty {
+                NSLog("DittoDrawingModel.drawing(): Failed to decode stroke(s) for key: %@", key)
             }
-            return stroke
+            return decoded
         }
         return PKDrawing(strokes: strokes)
     }
@@ -57,14 +58,13 @@ struct DittoDrawingModel {
         strokeMap = map
         creationDateToKey = [:]
         keyToCreationDate = [:]
-        maskFingerprints = [:]
+        groupFingerprints = [:]
         for (key, encoded) in map {
-            if let stroke = DittoStrokeModel.decode(from: encoded) {
-                creationDateToKey[stroke.path.creationDate] = key
-                keyToCreationDate[key] = stroke.path.creationDate
-                if let fp = DittoStrokeModel.maskFingerprint(for: stroke) {
-                    maskFingerprints[key] = fp
-                }
+            let strokes = DittoStrokeModel.decodeGroup(from: encoded)
+            if let first = strokes.first {
+                creationDateToKey[first.path.creationDate] = key
+                keyToCreationDate[key] = first.path.creationDate
+                groupFingerprints[key] = DittoStrokeModel.groupFingerprint(for: strokes)
             }
         }
     }
@@ -73,10 +73,15 @@ struct DittoDrawingModel {
 
     /// Builds the full desired strokes map from current canvas strokes.
     ///
-    /// For known strokes whose mask hasn't changed, reuses the stored encoding from `knownStrokeMap`
+    /// Groups strokes by `creationDate` to handle bitmap eraser splits and the rare case of
+    /// unrelated strokes sharing a timestamp. All strokes in a group are encoded together as a
+    /// multi-stroke PKDrawing under one Ditto key, so no data is lost on collision.
+    ///
+    /// For known groups whose fingerprint hasn't changed, reuses the stored encoding
     /// (PKDrawing encoding is non-deterministic across instances, so re-encoding would produce
     /// different bytes and cause unnecessary Ditto replication or concurrent write conflicts).
-    /// For new strokes or strokes with mask changes, encodes fresh.
+    /// For new groups or groups with fingerprint changes (mask change, split, or piece
+    /// deletion), encodes fresh.
     ///
     /// Also detects removes: known keys not present on the canvas.
     ///
@@ -85,30 +90,43 @@ struct DittoDrawingModel {
         currentStrokes: [PKStroke],
         knownCreationDateToKey: [Date: String],
         knownStrokeMap: [String: String],
-        knownMaskFingerprints: [String: Data]
+        knownGroupFingerprints: [String: Data]
     ) -> (desired: [String: String], removes: [String], newMappings: [(date: Date, key: String)]) {
         var desired: [String: String] = [:]
         var newMappings: [(date: Date, key: String)] = []
 
+        // Group strokes by creationDate, preserving z-order within each group
+        var strokesByDate: [(date: Date, strokes: [PKStroke])] = []
+        var dateIndex: [Date: Int] = [:]
         for stroke in currentStrokes {
-            if let existingKey = knownCreationDateToKey[stroke.path.creationDate] {
-                // Known stroke — check if mask changed via deterministic fingerprint
-                let currentFP = DittoStrokeModel.maskFingerprint(for: stroke)
-                let storedFP = knownMaskFingerprints[existingKey]
+            let date = stroke.path.creationDate
+            if let idx = dateIndex[date] {
+                strokesByDate[idx].strokes.append(stroke)
+            } else {
+                dateIndex[date] = strokesByDate.count
+                strokesByDate.append((date: date, strokes: [stroke]))
+            }
+        }
+
+        for (date, group) in strokesByDate {
+            if let existingKey = knownCreationDateToKey[date] {
+                // Known group — check if fingerprint changed (mask change or split)
+                let currentFP = DittoStrokeModel.groupFingerprint(for: group)
+                let storedFP = knownGroupFingerprints[existingKey]
                 if currentFP == storedFP, let storedEncoding = knownStrokeMap[existingKey] {
-                    // Mask unchanged — reuse stored encoding to avoid non-deterministic re-encoding
+                    // Group unchanged — reuse stored encoding
                     desired[existingKey] = storedEncoding
                 } else {
-                    // Mask changed — re-encode
-                    guard let encoded = DittoStrokeModel.encode(stroke) else { continue }
+                    // Group changed (mask change, split, or piece deletion) — re-encode
+                    guard let encoded = DittoStrokeModel.encodeGroup(group) else { continue }
                     desired[existingKey] = encoded
                 }
             } else {
-                // New stroke
-                guard let encoded = DittoStrokeModel.encode(stroke) else { continue }
-                let key = DittoStrokeModel.generateKey(for: stroke.path.creationDate)
+                // New stroke group
+                guard let encoded = DittoStrokeModel.encodeGroup(group) else { continue }
+                let key = DittoStrokeModel.generateKey(for: date)
                 desired[key] = encoded
-                newMappings.append((date: stroke.path.creationDate, key: key))
+                newMappings.append((date: date, key: key))
             }
         }
 
@@ -143,14 +161,14 @@ struct DittoDrawingModel {
             strokeMap[key] = encoded
         }
 
-        // Update mask fingerprints from current strokes
+        // Update group fingerprints from current strokes grouped by date
+        var strokesByDate: [Date: [PKStroke]] = [:]
         for stroke in currentStrokes {
-            if let key = creationDateToKey[stroke.path.creationDate] {
-                if let fp = DittoStrokeModel.maskFingerprint(for: stroke) {
-                    maskFingerprints[key] = fp
-                } else {
-                    maskFingerprints.removeValue(forKey: key)
-                }
+            strokesByDate[stroke.path.creationDate, default: []].append(stroke)
+        }
+        for (date, group) in strokesByDate {
+            if let key = creationDateToKey[date] {
+                groupFingerprints[key] = DittoStrokeModel.groupFingerprint(for: group)
             }
         }
 
@@ -168,20 +186,19 @@ struct DittoDrawingModel {
             keyToCreationDate.removeValue(forKey: mapping.key)
         }
 
-        // Restore old strokeMap values and recalculate fingerprints
+        // Restore old strokeMap values and recalculate group fingerprints
         for (key, oldValue) in oldValues {
             if let old = oldValue {
                 strokeMap[key] = old
-                if let stroke = DittoStrokeModel.decode(from: old) {
-                    if let fp = DittoStrokeModel.maskFingerprint(for: stroke) {
-                        maskFingerprints[key] = fp
-                    } else {
-                        maskFingerprints.removeValue(forKey: key)
-                    }
+                let strokes = DittoStrokeModel.decodeGroup(from: old)
+                if !strokes.isEmpty {
+                    groupFingerprints[key] = DittoStrokeModel.groupFingerprint(for: strokes)
+                } else {
+                    groupFingerprints.removeValue(forKey: key)
                 }
             } else {
                 strokeMap.removeValue(forKey: key)
-                maskFingerprints.removeValue(forKey: key)
+                groupFingerprints.removeValue(forKey: key)
             }
         }
     }
@@ -196,7 +213,7 @@ struct DittoDrawingModel {
                 keyToCreationDate.removeValue(forKey: key)
             }
             strokeMap.removeValue(forKey: key)
-            maskFingerprints.removeValue(forKey: key)
+            groupFingerprints.removeValue(forKey: key)
         }
     }
 }

--- a/DrawTogether/DrawTogether/DittoDrawingModel.swift
+++ b/DrawTogether/DrawTogether/DittoDrawingModel.swift
@@ -9,18 +9,23 @@ import Foundation
 import PencilKit
 
 /// Manages the sync state for a single drawing document in Ditto.
-/// Tracks which strokes are known (synced) and provides diffing to detect local changes.
+/// Tracks which strokes are known (synced) and builds the desired state for outbound sync.
 struct DittoDrawingModel {
     let drawingID: String
 
-    /// Maps Ditto key (ISO8601 timestamp string) to JSON-encoded single-stroke PKDrawing
+    /// Maps Ditto key (ISO8601 timestamp string) to encoded single-stroke PKDrawing
     private(set) var strokeMap: [String: String] = [:]
 
-    /// Maps stroke creation date to Ditto key, for stable diffing
+    /// Maps stroke creation date to Ditto key, for key reuse and remove detection
     private(set) var creationDateToKey: [Date: String] = [:]
 
     /// Reverse map: Ditto key to creation date, for O(1) removal lookups
     private(set) var keyToCreationDate: [String: Date] = [:]
+
+    /// Mask fingerprints for known strokes, used to detect bitmap eraser modifications.
+    /// Key is the Ditto key; value is NSKeyedArchiver data of the UIBezierPath mask.
+    /// Absent entry means the stroke has no mask.
+    private(set) var maskFingerprints: [String: Data] = [:]
 
     init(drawingID: String = "1") {
         self.drawingID = drawingID
@@ -32,11 +37,11 @@ struct DittoDrawingModel {
     func drawing() -> PKDrawing {
         let sortedKeys = strokeMap.keys.sorted()
         let strokes: [PKStroke] = sortedKeys.compactMap { key in
-            guard let json = strokeMap[key] else {
+            guard let encoded = strokeMap[key] else {
                 NSLog("DittoDrawingModel.drawing(): Missing data for stroke key: %@", key)
                 return nil
             }
-            guard let stroke = DittoStrokeModel.decode(from: json) else {
+            guard let stroke = DittoStrokeModel.decode(from: encoded) else {
                 NSLog("DittoDrawingModel.drawing(): Failed to decode stroke for key: %@", key)
                 return nil
             }
@@ -52,89 +57,146 @@ struct DittoDrawingModel {
         strokeMap = map
         creationDateToKey = [:]
         keyToCreationDate = [:]
-        for (key, json) in map {
-            if let stroke = DittoStrokeModel.decode(from: json) {
+        maskFingerprints = [:]
+        for (key, encoded) in map {
+            if let stroke = DittoStrokeModel.decode(from: encoded) {
                 creationDateToKey[stroke.path.creationDate] = key
                 keyToCreationDate[key] = stroke.path.creationDate
+                if let fp = DittoStrokeModel.maskFingerprint(for: stroke) {
+                    maskFingerprints[key] = fp
+                }
             }
         }
     }
 
-    // MARK: - Diffing
+    // MARK: - Build Desired State
 
-    /// Compares current canvas strokes against a snapshot of known state using creation dates as
-    /// stable identifiers. Returns inserts (key -> JSON string) and removes (keys to UNSET).
+    /// Builds the full desired strokes map from current canvas strokes.
     ///
-    /// This is a pure function that can run off the main thread — it takes a snapshot of known
-    /// dates/keys rather than reading from `self`. The caller is responsible for persisting the
-    /// returned key mappings via `persistPendingKeys`.
+    /// For known strokes whose mask hasn't changed, reuses the stored encoding from `knownStrokeMap`
+    /// (PKDrawing encoding is non-deterministic across instances, so re-encoding would produce
+    /// different bytes and cause unnecessary Ditto replication or concurrent write conflicts).
+    /// For new strokes or strokes with mask changes, encodes fresh.
     ///
-    /// Strokes are identified by `PKStrokePath.creationDate`, which PencilKit assigns uniquely when
-    /// a stroke is drawn. This only detects new and removed strokes — in-place modifications to
-    /// existing strokes (same creationDate, different content) are not detected.
+    /// Also detects removes: known keys not present on the canvas.
     ///
-    /// Known limitation: the bitmap eraser sets a `mask` on existing strokes without changing their
-    /// creationDate, so eraser changes are not synced. The vector eraser works correctly because it
-    /// removes/splits strokes, producing new creationDates. See: https://github.com/bplattenburg/DrawTogether/issues/8
-    static func computeDiff(
+    /// This is a pure function that can run off the main thread.
+    static func buildDesiredState(
         currentStrokes: [PKStroke],
-        knownCreationDateToKey: [Date: String]
-    ) -> (inserts: [String: String], removes: [String], newMappings: [(date: Date, key: String)]) {
-        let currentDates = Set(currentStrokes.map { $0.path.creationDate })
-        let knownDates = Set(knownCreationDateToKey.keys)
-
-        // Strokes in canvas but not known -> new
-        var inserts: [String: String] = [:]
+        knownCreationDateToKey: [Date: String],
+        knownStrokeMap: [String: String],
+        knownMaskFingerprints: [String: Data]
+    ) -> (desired: [String: String], removes: [String], newMappings: [(date: Date, key: String)]) {
+        var desired: [String: String] = [:]
         var newMappings: [(date: Date, key: String)] = []
-        for stroke in currentStrokes where !knownDates.contains(stroke.path.creationDate) {
-            guard let json = DittoStrokeModel.encode(stroke) else { continue }
-            let key = DittoStrokeModel.generateKey(for: stroke.path.creationDate)
-            inserts[key] = json
-            newMappings.append((date: stroke.path.creationDate, key: key))
+
+        for stroke in currentStrokes {
+            if let existingKey = knownCreationDateToKey[stroke.path.creationDate] {
+                // Known stroke — check if mask changed via deterministic fingerprint
+                let currentFP = DittoStrokeModel.maskFingerprint(for: stroke)
+                let storedFP = knownMaskFingerprints[existingKey]
+                if currentFP == storedFP, let storedEncoding = knownStrokeMap[existingKey] {
+                    // Mask unchanged — reuse stored encoding to avoid non-deterministic re-encoding
+                    desired[existingKey] = storedEncoding
+                } else {
+                    // Mask changed — re-encode
+                    guard let encoded = DittoStrokeModel.encode(stroke) else { continue }
+                    desired[existingKey] = encoded
+                }
+            } else {
+                // New stroke
+                guard let encoded = DittoStrokeModel.encode(stroke) else { continue }
+                let key = DittoStrokeModel.generateKey(for: stroke.path.creationDate)
+                desired[key] = encoded
+                newMappings.append((date: stroke.path.creationDate, key: key))
+            }
         }
 
-        // Strokes known but not in canvas -> removed
-        let removes = knownDates.subtracting(currentDates).compactMap { knownCreationDateToKey[$0] }
+        // Keys known locally but not on canvas → removes
+        let currentKeys = Set(desired.keys)
+        let knownKeys = Set(knownCreationDateToKey.values)
+        let removes = Array(knownKeys.subtracting(currentKeys))
 
-        return (inserts: inserts, removes: removes, newMappings: newMappings)
+        return (desired: desired, removes: removes, newMappings: newMappings)
     }
 
-    /// Persists key mappings from a `computeDiff` result so repeated diffs won't generate duplicates.
-    mutating func persistPendingKeys(_ mappings: [(date: Date, key: String)]) {
-        for mapping in mappings {
+    // MARK: - Pending State Management
+
+    /// Persists key mappings and stroke data from a buildDesiredState result so repeated
+    /// calls won't generate duplicates or re-detect the same changes.
+    /// Returns old strokeMap values for rollback on transaction failure.
+    mutating func persistPending(
+        newMappings: [(date: Date, key: String)],
+        desired: [String: String],
+        currentStrokes: [PKStroke]
+    ) -> [String: String?] {
+        // Track new key mappings
+        for mapping in newMappings {
             creationDateToKey[mapping.date] = mapping.key
             keyToCreationDate[mapping.key] = mapping.date
+        }
+
+        // Update strokeMap and capture old values for rollback
+        var oldValues: [String: String?] = [:]
+        for (key, encoded) in desired {
+            oldValues[key] = strokeMap[key]
+            strokeMap[key] = encoded
+        }
+
+        // Update mask fingerprints from current strokes
+        for stroke in currentStrokes {
+            if let key = creationDateToKey[stroke.path.creationDate] {
+                if let fp = DittoStrokeModel.maskFingerprint(for: stroke) {
+                    maskFingerprints[key] = fp
+                } else {
+                    maskFingerprints.removeValue(forKey: key)
+                }
+            }
+        }
+
+        return oldValues
+    }
+
+    /// Rolls back changes from persistPending when a transaction fails.
+    mutating func rollbackPending(
+        oldValues: [String: String?],
+        newMappings: [(date: Date, key: String)]
+    ) {
+        // Remove new key mappings
+        for mapping in newMappings {
+            creationDateToKey.removeValue(forKey: mapping.date)
+            keyToCreationDate.removeValue(forKey: mapping.key)
+        }
+
+        // Restore old strokeMap values and recalculate fingerprints
+        for (key, oldValue) in oldValues {
+            if let old = oldValue {
+                strokeMap[key] = old
+                if let stroke = DittoStrokeModel.decode(from: old) {
+                    if let fp = DittoStrokeModel.maskFingerprint(for: stroke) {
+                        maskFingerprints[key] = fp
+                    } else {
+                        maskFingerprints.removeValue(forKey: key)
+                    }
+                }
+            } else {
+                strokeMap.removeValue(forKey: key)
+                maskFingerprints.removeValue(forKey: key)
+            }
         }
     }
 
     // MARK: - Apply Changes
 
-    /// Rolls back key mappings that were optimistically persisted by diff() when a transaction fails.
-    /// This allows the strokes to be re-detected and re-synced on the next diff.
-    mutating func rollbackPendingKeys(inserts: [String: String]) {
-        for key in inserts.keys {
-            if let date = keyToCreationDate[key] {
-                creationDateToKey.removeValue(forKey: date)
-                keyToCreationDate.removeValue(forKey: key)
-            }
-        }
-    }
-
-    /// Updates internal state after a diff has been synced to Ditto
-    mutating func apply(inserts: [String: String], removes: [String]) {
+    /// Removes keys from internal state after successful UNSET in Ditto.
+    mutating func applyRemoves(_ removes: [String]) {
         for key in removes {
             if let date = keyToCreationDate[key] {
                 creationDateToKey.removeValue(forKey: date)
                 keyToCreationDate.removeValue(forKey: key)
             }
             strokeMap.removeValue(forKey: key)
-        }
-        for (key, json) in inserts {
-            strokeMap[key] = json
-            if let stroke = DittoStrokeModel.decode(from: json) {
-                creationDateToKey[stroke.path.creationDate] = key
-                keyToCreationDate[key] = stroke.path.creationDate
-            }
+            maskFingerprints.removeValue(forKey: key)
         }
     }
 }

--- a/DrawTogether/DrawTogether/DittoDrawingModel.swift
+++ b/DrawTogether/DrawTogether/DittoDrawingModel.swift
@@ -27,7 +27,7 @@ struct DittoDrawingModel {
     /// encoding stroke count and each stroke's mask data.
     private(set) var groupFingerprints: [String: Data] = [:]
 
-    init(drawingID: String = "1") {
+    init(drawingID: String = "2") {
         self.drawingID = drawingID
     }
 

--- a/DrawTogether/DrawTogether/DittoStrokeModel.swift
+++ b/DrawTogether/DrawTogether/DittoStrokeModel.swift
@@ -8,14 +8,15 @@
 import Foundation
 import PencilKit
 
-/// Handles encoding, decoding, and key generation for individual PKStrokes.
-/// Each stroke is serialized by wrapping it in a single-stroke PKDrawing and using
-/// `dataRepresentation()` (Apple's recommended persistence path), which preserves all stroke
-/// properties including masks set by the bitmap eraser.
+/// Handles encoding, decoding, and key generation for PKStroke groups.
+/// Strokes are serialized as PKDrawings via `dataRepresentation()` (Apple's recommended
+/// persistence path), which preserves all stroke properties including masks set by the bitmap
+/// eraser. Multiple strokes sharing a `creationDate` (e.g., bitmap eraser splits or rare
+/// timestamp collisions) are packed into a single multi-stroke PKDrawing under one key.
 ///
-/// Note: encoding is NOT deterministic across PKDrawing instances — re-wrapping the same stroke
-/// produces different bytes each time. Callers must store and reuse encoded values rather than
-/// re-encoding for comparison. Use `maskFingerprint(for:)` for change detection.
+/// Note: encoding is NOT deterministic across PKDrawing instances — re-encoding the same
+/// strokes produces different bytes each time. Callers must store and reuse encoded values
+/// rather than re-encoding for comparison. Use `groupFingerprint(for:)` for change detection.
 ///
 /// Keys are ISO8601 timestamps derived from `PKStrokePath.creationDate`, which PencilKit assigns
 /// uniquely when a stroke is drawn, giving deterministic and chronologically sortable keys.
@@ -25,15 +26,23 @@ struct DittoStrokeModel {
     /// Preserves all stroke properties including masks. NOT deterministic across calls —
     /// store the result and reuse it rather than re-encoding for comparison.
     static func encode(_ stroke: PKStroke) -> String? {
-        let wrapper = PKDrawing(strokes: [stroke])
+        encodeGroup([stroke])
+    }
+
+    /// Encodes multiple PKStrokes (e.g., split pieces sharing a `creationDate`) as a single
+    /// base64-encoded PKDrawing. Preserves stroke order, which determines z-order on decode.
+    static func encodeGroup(_ strokes: [PKStroke]) -> String? {
+        guard !strokes.isEmpty else { return nil }
+        let wrapper = PKDrawing(strokes: strokes)
         return wrapper.dataRepresentation().base64EncodedString()
     }
 
-    /// Decodes a PKStroke from a base64-encoded `PKDrawing.dataRepresentation()` string.
-    static func decode(from encoded: String) -> PKStroke? {
+    /// Decodes all PKStrokes from a base64-encoded `PKDrawing.dataRepresentation()` string.
+    /// Returns an empty array on failure. A single-stroke encoding returns a 1-element array.
+    static func decodeGroup(from encoded: String) -> [PKStroke] {
         guard let data = Data(base64Encoded: encoded),
-              let drawing = try? PKDrawing(data: data) else { return nil }
-        return drawing.strokes.first
+              let drawing = try? PKDrawing(data: data) else { return [] }
+        return drawing.strokes
     }
 
     /// Returns a deterministic fingerprint of a stroke's mask for change detection.
@@ -44,12 +53,33 @@ struct DittoStrokeModel {
         return try? NSKeyedArchiver.archivedData(withRootObject: mask, requiringSecureCoding: true)
     }
 
+    /// Returns a deterministic fingerprint for a group of strokes (e.g., split pieces).
+    /// Captures stroke count and each stroke's mask, so any split, mask change, or piece
+    /// deletion is detected. Returns stable bytes for unchanged groups.
+    static func groupFingerprint(for strokes: [PKStroke]) -> Data {
+        var data = Data()
+        var count = UInt32(strokes.count)
+        data.append(Data(bytes: &count, count: 4))
+        for stroke in strokes {
+            if let maskFP = maskFingerprint(for: stroke) {
+                var len = UInt32(maskFP.count)
+                data.append(Data(bytes: &len, count: 4))
+                data.append(maskFP)
+            } else {
+                var zero = UInt32(0)
+                data.append(Data(bytes: &zero, count: 4))
+            }
+        }
+        return data
+    }
+
     /// Generates a deterministic, sortable key from a stroke's creation date.
     /// ISO8601 with fractional seconds (millisecond precision) ensures lexicographic sort = chronological order.
     /// Collisions require two strokes created within the same millisecond, which is practically impossible:
     /// each stroke requires physical drawing input that far exceeds 1ms, and PencilKit serializes stroke
-    /// creation on the main thread. Cross-device collisions at the same millisecond would merge via
-    /// Ditto's MAP CRDT (last-write-wins per key), not cause data loss.
+    /// creation on the main thread. If a collision does occur (or PencilKit produces multiple strokes with
+    /// the same `creationDate`, e.g., bitmap eraser splits), the strokes are grouped and encoded together
+    /// under one key via `encodeGroup`, so no data is lost.
     static func generateKey(for date: Date) -> String {
         ISO8601DateFormatter.fractional.string(from: date)
     }

--- a/DrawTogether/DrawTogether/DittoStrokeModel.swift
+++ b/DrawTogether/DrawTogether/DittoStrokeModel.swift
@@ -9,26 +9,39 @@ import Foundation
 import PencilKit
 
 /// Handles encoding, decoding, and key generation for individual PKStrokes.
-/// Each stroke is serialized by wrapping it in a single-stroke PKDrawing (since PKStroke is not Codable).
+/// Each stroke is serialized by wrapping it in a single-stroke PKDrawing and using
+/// `dataRepresentation()` (Apple's recommended persistence path), which preserves all stroke
+/// properties including masks set by the bitmap eraser.
+///
+/// Note: encoding is NOT deterministic across PKDrawing instances — re-wrapping the same stroke
+/// produces different bytes each time. Callers must store and reuse encoded values rather than
+/// re-encoding for comparison. Use `maskFingerprint(for:)` for change detection.
+///
 /// Keys are ISO8601 timestamps derived from `PKStrokePath.creationDate`, which PencilKit assigns
 /// uniquely when a stroke is drawn, giving deterministic and chronologically sortable keys.
 struct DittoStrokeModel {
 
-    /// Encodes a PKStroke as a JSON string (via single-stroke PKDrawing wrapper).
-    /// Note: JSON encoding via PKDrawing's Codable conformance may not preserve the `mask` property
-    /// set by the bitmap eraser. The official persistence path is `PKDrawing.dataRepresentation()`.
-    /// See: https://github.com/bplattenburg/DrawTogether/issues/8
+    /// Encodes a PKStroke as a base64 string via `PKDrawing.dataRepresentation()`.
+    /// Preserves all stroke properties including masks. NOT deterministic across calls —
+    /// store the result and reuse it rather than re-encoding for comparison.
     static func encode(_ stroke: PKStroke) -> String? {
         let wrapper = PKDrawing(strokes: [stroke])
-        guard let data = try? JSONEncoder().encode(wrapper) else { return nil }
-        return String(data: data, encoding: .utf8)
+        return wrapper.dataRepresentation().base64EncodedString()
     }
 
-    /// Decodes a PKStroke from a JSON string (via single-stroke PKDrawing wrapper)
-    static func decode(from json: String) -> PKStroke? {
-        guard let data = json.data(using: .utf8),
-              let wrapper = try? JSONDecoder().decode(PKDrawing.self, from: data) else { return nil }
-        return wrapper.strokes.first
+    /// Decodes a PKStroke from a base64-encoded `PKDrawing.dataRepresentation()` string.
+    static func decode(from encoded: String) -> PKStroke? {
+        guard let data = Data(base64Encoded: encoded),
+              let drawing = try? PKDrawing(data: data) else { return nil }
+        return drawing.strokes.first
+    }
+
+    /// Returns a deterministic fingerprint of a stroke's mask for change detection.
+    /// NSKeyedArchiver produces identical output for the same UIBezierPath, making this
+    /// safe for equality comparison. Returns nil if the stroke has no mask.
+    static func maskFingerprint(for stroke: PKStroke) -> Data? {
+        guard let mask = stroke.mask else { return nil }
+        return try? NSKeyedArchiver.archivedData(withRootObject: mask, requiringSecureCoding: true)
     }
 
     /// Generates a deterministic, sortable key from a stroke's creation date.

--- a/DrawTogether/DrawTogether/DrawingSyncCoordinator.swift
+++ b/DrawTogether/DrawTogether/DrawingSyncCoordinator.swift
@@ -35,10 +35,6 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
     /// Debounce interval for coalescing rapid drawing changes
     let syncDebounceNanoseconds: UInt64
 
-    /// Stored for rollback on transaction failure
-    private var pendingOldValues: [String: String?] = [:]
-    private var pendingNewMappings: [(date: Date, key: String)] = []
-
     init(_ parent: CanvasView, ditto: Ditto = DittoManager.shared.ditto, syncDebounceNanoseconds: UInt64 = 100_000_000) {
         self.parent = parent
         self.ditto = ditto
@@ -90,15 +86,16 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
             )
             guard !desired.isEmpty || !removes.isEmpty else { return }
 
-            // Persist pending state on main to prevent duplicate inserts on repeated diffs
-            await MainActor.run {
-                guard let self else { return }
-                self.pendingNewMappings = newMappings
-                self.pendingOldValues = self.model.persistPending(
+            // Persist pending state on main to prevent duplicate inserts on repeated diffs.
+            // Capture rollback data as task-locals so concurrent task replacement can't corrupt them.
+            let (oldValues, pendingMappings) = await MainActor.run { () -> ([String: String?], [(date: Date, key: String)]) in
+                guard let self else { return ([:], []) }
+                let old = self.model.persistPending(
                     newMappings: newMappings,
                     desired: desired,
                     currentStrokes: syncContext.strokes
                 )
+                return (old, newMappings)
             }
 
             // Run Ditto transaction off main
@@ -127,10 +124,9 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
             } catch {
                 // Rollback optimistic state so changes can be re-synced on next diff
                 await MainActor.run {
-                    guard let self else { return }
-                    self.model.rollbackPending(
-                        oldValues: self.pendingOldValues,
-                        newMappings: self.pendingNewMappings
+                    self?.model.rollbackPending(
+                        oldValues: oldValues,
+                        newMappings: pendingMappings
                     )
                 }
                 NSLog("Error syncing strokes: %@", "\(error)")

--- a/DrawTogether/DrawTogether/DrawingSyncCoordinator.swift
+++ b/DrawTogether/DrawTogether/DrawingSyncCoordinator.swift
@@ -10,7 +10,7 @@ import PencilKit
 import DittoSwift
 
 /// Coordinates bidirectional sync between a PKCanvasView and Ditto.
-/// Observes local drawing changes, diffs strokes, and syncs to Ditto via transactions.
+/// Observes local drawing changes, builds the desired state, and syncs to Ditto via transactions.
 /// Observes remote Ditto changes and rebuilds the local drawing, preserving uncommitted local strokes.
 class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
     var parent: CanvasView
@@ -34,6 +34,10 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
 
     /// Debounce interval for coalescing rapid drawing changes
     let syncDebounceNanoseconds: UInt64
+
+    /// Stored for rollback on transaction failure
+    private var pendingOldValues: [String: String?] = [:]
+    private var pendingNewMappings: [(date: Date, key: String)] = []
 
     init(_ parent: CanvasView, ditto: Ditto = DittoManager.shared.ditto, syncDebounceNanoseconds: UInt64 = 100_000_000) {
         self.parent = parent
@@ -71,29 +75,39 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
             }
 
             // Capture current state on main
-            guard let syncContext = await MainActor.run(body: { () -> (strokes: [PKStroke], drawingID: String, ditto: Ditto, knownCreationDateToKey: [Date: String])? in
+            guard let syncContext = await MainActor.run(body: { () -> (strokes: [PKStroke], drawingID: String, ditto: Ditto, knownCreationDateToKey: [Date: String], knownStrokeMap: [String: String], knownMaskFingerprints: [String: Data])? in
                 guard let self, !self.isUpdatingFromDitto,
                       let strokes = self.canvasView?.drawing.strokes else { return nil }
-                return (strokes: strokes, drawingID: self.model.drawingID, ditto: self.ditto, knownCreationDateToKey: self.model.creationDateToKey)
+                return (strokes: strokes, drawingID: self.model.drawingID, ditto: self.ditto, knownCreationDateToKey: self.model.creationDateToKey, knownStrokeMap: self.model.strokeMap, knownMaskFingerprints: self.model.maskFingerprints)
             }) else { return }
 
-            // Diff off main — encoding can be CPU-intensive for many strokes
-            let (inserts, removes, newMappings) = DittoDrawingModel.computeDiff(
+            // Build desired state off main — encoding can be CPU-intensive for many strokes
+            let (desired, removes, newMappings) = DittoDrawingModel.buildDesiredState(
                 currentStrokes: syncContext.strokes,
-                knownCreationDateToKey: syncContext.knownCreationDateToKey
+                knownCreationDateToKey: syncContext.knownCreationDateToKey,
+                knownStrokeMap: syncContext.knownStrokeMap,
+                knownMaskFingerprints: syncContext.knownMaskFingerprints
             )
-            guard !inserts.isEmpty || !removes.isEmpty else { return }
+            guard !desired.isEmpty || !removes.isEmpty else { return }
 
-            // Persist key mappings on main to prevent duplicate inserts on repeated diffs
-            await MainActor.run { self?.model.persistPendingKeys(newMappings) }
+            // Persist pending state on main to prevent duplicate inserts on repeated diffs
+            await MainActor.run {
+                guard let self else { return }
+                self.pendingNewMappings = newMappings
+                self.pendingOldValues = self.model.persistPending(
+                    newMappings: newMappings,
+                    desired: desired,
+                    currentStrokes: syncContext.strokes
+                )
+            }
 
             // Run Ditto transaction off main
             do {
                 try await syncContext.ditto.store.transaction { transaction in
-                    if !inserts.isEmpty {
-                        let doc: [String: Any] = ["_id": syncContext.drawingID, "strokes": inserts]
+                    if !desired.isEmpty {
+                        let doc: [String: Any] = ["_id": syncContext.drawingID, "strokes": desired]
                         try await transaction.execute(
-                            query: "INSERT INTO drawings VALUES (:doc) ON ID CONFLICT DO MERGE",
+                            query: "INSERT INTO drawings VALUES (:doc) ON ID CONFLICT DO UPDATE_LOCAL_DIFF",
                             arguments: ["doc": doc]
                         )
                     }
@@ -108,11 +122,17 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
                     return .commit
                 }
 
-                // Apply on main after successful commit
-                await MainActor.run { self?.model.apply(inserts: inserts, removes: removes) }
+                // Apply removes on main after successful commit
+                await MainActor.run { self?.model.applyRemoves(removes) }
             } catch {
-                // Rollback optimistic key mappings so strokes can be re-synced on next diff
-                await MainActor.run { self?.model.rollbackPendingKeys(inserts: inserts) }
+                // Rollback optimistic state so changes can be re-synced on next diff
+                await MainActor.run {
+                    guard let self else { return }
+                    self.model.rollbackPending(
+                        oldValues: self.pendingOldValues,
+                        newMappings: self.pendingNewMappings
+                    )
+                }
                 NSLog("Error syncing strokes: %@", "\(error)")
             }
         }

--- a/DrawTogether/DrawTogether/DrawingSyncCoordinator.swift
+++ b/DrawTogether/DrawTogether/DrawingSyncCoordinator.swift
@@ -71,10 +71,10 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
             }
 
             // Capture current state on main
-            guard let syncContext = await MainActor.run(body: { () -> (strokes: [PKStroke], drawingID: String, ditto: Ditto, knownCreationDateToKey: [Date: String], knownStrokeMap: [String: String], knownMaskFingerprints: [String: Data])? in
+            guard let syncContext = await MainActor.run(body: { () -> (strokes: [PKStroke], drawingID: String, ditto: Ditto, knownCreationDateToKey: [Date: String], knownStrokeMap: [String: String], knownGroupFingerprints: [String: Data])? in
                 guard let self, !self.isUpdatingFromDitto,
                       let strokes = self.canvasView?.drawing.strokes else { return nil }
-                return (strokes: strokes, drawingID: self.model.drawingID, ditto: self.ditto, knownCreationDateToKey: self.model.creationDateToKey, knownStrokeMap: self.model.strokeMap, knownMaskFingerprints: self.model.maskFingerprints)
+                return (strokes: strokes, drawingID: self.model.drawingID, ditto: self.ditto, knownCreationDateToKey: self.model.creationDateToKey, knownStrokeMap: self.model.strokeMap, knownGroupFingerprints: self.model.groupFingerprints)
             }) else { return }
 
             // Build desired state off main — encoding can be CPU-intensive for many strokes
@@ -82,7 +82,7 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
                 currentStrokes: syncContext.strokes,
                 knownCreationDateToKey: syncContext.knownCreationDateToKey,
                 knownStrokeMap: syncContext.knownStrokeMap,
-                knownMaskFingerprints: syncContext.knownMaskFingerprints
+                knownGroupFingerprints: syncContext.knownGroupFingerprints
             )
             guard !desired.isEmpty || !removes.isEmpty else { return }
 

--- a/DrawTogether/DrawTogetherTests/DittoDrawingModelTests.swift
+++ b/DrawTogether/DrawTogetherTests/DittoDrawingModelTests.swift
@@ -26,7 +26,7 @@ final class DittoDrawingModelTests: XCTestCase {
         DittoStrokeModel.encode(stroke)
     }
 
-    /// Sets up a model with known strokes and returns the strokes for reuse in assertions.
+    /// Populates the given model with the provided strokes.
     private func modelWithKnownStrokes(_ model: inout DittoDrawingModel, strokes: [(stroke: PKStroke, key: String)]) {
         var map: [String: String] = [:]
         for (stroke, key) in strokes {

--- a/DrawTogether/DrawTogetherTests/DittoDrawingModelTests.swift
+++ b/DrawTogether/DrawTogetherTests/DittoDrawingModelTests.swift
@@ -13,7 +13,6 @@ final class DittoDrawingModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Creates a simple PKStroke with a unique creation date
     private func makeStroke(at point: CGPoint = CGPoint(x: 100, y: 100), creationDate: Date = Date()) -> PKStroke {
         let ink = PKInk(.pen, color: .black)
         let path = PKStrokePath(controlPoints: [
@@ -23,23 +22,21 @@ final class DittoDrawingModelTests: XCTestCase {
         return PKStroke(ink: ink, path: path)
     }
 
-    /// Encodes a stroke as a JSON string using DittoStrokeModel
     private func encodeStroke(_ stroke: PKStroke) -> String? {
         DittoStrokeModel.encode(stroke)
     }
 
-    // MARK: - Diff Tests
-
-    func testDiffDoesNotDuplicateOnRepeatedCalls() {
-        var model = DittoDrawingModel()
-        let stroke = makeStroke(at: CGPoint(x: 42, y: 42), creationDate: Date(timeIntervalSince1970: 1000))
-
-        let result1 = DittoDrawingModel.computeDiff(currentStrokes: [stroke], knownCreationDateToKey: model.creationDateToKey)
-        model.persistPendingKeys(result1.newMappings)
-        let result2 = DittoDrawingModel.computeDiff(currentStrokes: [stroke], knownCreationDateToKey: model.creationDateToKey)
-
-        XCTAssertEqual(result1.inserts.count, 1, "First diff should detect 1 new stroke")
-        XCTAssertTrue(result2.inserts.isEmpty, "Second diff should produce no inserts — key was persisted on first call")
+    /// Sets up a model with known strokes and returns the strokes for reuse in assertions.
+    private func modelWithKnownStrokes(_ model: inout DittoDrawingModel, strokes: [(stroke: PKStroke, key: String)]) {
+        var map: [String: String] = [:]
+        for (stroke, key) in strokes {
+            guard let encoded = encodeStroke(stroke) else {
+                XCTFail("Failed to encode stroke")
+                return
+            }
+            map[key] = encoded
+        }
+        model.updateFromStrokesMap(map)
     }
 
     // MARK: - Drawing Reconstruction Tests
@@ -55,217 +52,337 @@ final class DittoDrawingModelTests: XCTestCase {
         let stroke2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date2)
         let stroke3 = makeStroke(at: CGPoint(x: 90, y: 90), creationDate: date3)
 
-        guard let json1 = encodeStroke(stroke1),
-              let json2 = encodeStroke(stroke2),
-              let json3 = encodeStroke(stroke3) else {
-            XCTFail("Failed to encode strokes")
-            return
-        }
-
-        // Insert with out-of-order keys (timestamps are still chronological in the key string)
-        let strokesMap: [String: String] = [
-            "2026-03-25T12:00:02.000Z-CCC": json3,
-            "2026-03-25T12:00:00.000Z-AAA": json1,
-            "2026-03-25T12:00:01.000Z-BBB": json2,
-        ]
-        model.updateFromStrokesMap(strokesMap)
+        modelWithKnownStrokes(&model, strokes: [
+            (stroke1, "2026-03-25T12:00:00.000Z-AAA"),
+            (stroke2, "2026-03-25T12:00:01.000Z-BBB"),
+            (stroke3, "2026-03-25T12:00:02.000Z-CCC"),
+        ])
 
         let drawing = model.drawing()
         XCTAssertEqual(drawing.strokes.count, 3)
-
-        // Strokes should be in order based on sorted keys (AAA < BBB < CCC)
         XCTAssertEqual(drawing.strokes[0].path.first?.location.x ?? 0, 10, accuracy: 1)
         XCTAssertEqual(drawing.strokes[1].path.first?.location.x ?? 0, 50, accuracy: 1)
         XCTAssertEqual(drawing.strokes[2].path.first?.location.x ?? 0, 90, accuracy: 1)
     }
 
-    // MARK: - Diff Tests
+    // MARK: - Build Desired State Tests
 
-    func testDiffDetectsNewStrokes() {
-        var model = DittoDrawingModel()
+    func testBuildDesiredStateNewStrokes() {
+        let model = DittoDrawingModel()
+        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let stroke2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: Date(timeIntervalSince1970: 2000))
 
-        let existingDate = Date(timeIntervalSince1970: 1000)
-        let existingStroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: existingDate)
-        guard let existingJSON = encodeStroke(existingStroke) else {
-            XCTFail("Failed to encode stroke")
-            return
-        }
-        model.updateFromStrokesMap(["2026-03-25T12:00:00.000Z-AAA": existingJSON])
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke1, stroke2],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
 
-        // Canvas now has existing stroke + a new stroke with a different creation date
-        let newDate = Date(timeIntervalSince1970: 2000)
-        let newStroke = makeStroke(at: CGPoint(x: 200, y: 200), creationDate: newDate)
-        let result = DittoDrawingModel.computeDiff(currentStrokes: [existingStroke, newStroke], knownCreationDateToKey: model.creationDateToKey)
-
-        XCTAssertEqual(result.inserts.count, 1, "Should detect 1 new stroke")
-        XCTAssertTrue(result.removes.isEmpty, "Should not detect any removals")
+        XCTAssertEqual(result.desired.count, 2)
+        XCTAssertTrue(result.removes.isEmpty)
+        XCTAssertEqual(result.newMappings.count, 2)
     }
 
-    func testDiffDetectsMixedChanges() {
+    func testBuildDesiredStateReusesExistingKeys() {
         var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
 
-        let date1 = Date(timeIntervalSince1970: 1000)
-        let date2 = Date(timeIntervalSince1970: 2000)
-        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date1)
-        let stroke2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date2)
-        guard let json1 = encodeStroke(stroke1),
-              let json2 = encodeStroke(stroke2) else {
-            XCTFail("Failed to encode strokes")
-            return
-        }
-        model.updateFromStrokesMap([
-            "2026-03-25T12:00:00.000Z": json1,
-            "2026-03-25T12:00:01.000Z": json2,
-        ])
+        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
 
-        // Remove stroke2, add stroke3
-        let date3 = Date(timeIntervalSince1970: 3000)
-        let stroke3 = makeStroke(at: CGPoint(x: 200, y: 200), creationDate: date3)
-        let result = DittoDrawingModel.computeDiff(currentStrokes: [stroke1, stroke3], knownCreationDateToKey: model.creationDateToKey)
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
 
-        XCTAssertEqual(result.inserts.count, 1, "Should detect 1 new stroke")
-        XCTAssertEqual(result.removes.count, 1, "Should detect 1 removal")
-        XCTAssertEqual(result.removes.first, "2026-03-25T12:00:01.000Z")
+        XCTAssertEqual(result.desired.count, 1)
+        XCTAssertNotNil(result.desired[key], "Should reuse existing key")
+        XCTAssertTrue(result.newMappings.isEmpty, "Known stroke should not generate new mapping")
     }
 
-    func testDiffDetectsRemovedStrokes() {
+    func testBuildDesiredStateReusesEncodingForUnchangedStrokes() {
         var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
 
-        let date1 = Date(timeIntervalSince1970: 1000)
-        let date2 = Date(timeIntervalSince1970: 2000)
-        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date1)
-        let stroke2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date2)
-        guard let json1 = encodeStroke(stroke1),
-              let json2 = encodeStroke(stroke2) else {
-            XCTFail("Failed to encode strokes")
-            return
-        }
-        model.updateFromStrokesMap([
-            "2026-03-25T12:00:00.000Z-AAA": json1,
-            "2026-03-25T12:00:01.000Z-BBB": json2,
-        ])
+        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
+        let storedEncoding = model.strokeMap[key]!
 
-        // Canvas only has stroke1, stroke2 was removed
-        let result = DittoDrawingModel.computeDiff(currentStrokes: [stroke1], knownCreationDateToKey: model.creationDateToKey)
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
 
-        XCTAssertTrue(result.inserts.isEmpty, "Should not detect any inserts")
-        XCTAssertEqual(result.removes.count, 1, "Should detect 1 removal")
-        XCTAssertEqual(result.removes.first, "2026-03-25T12:00:01.000Z-BBB")
+        XCTAssertEqual(result.desired[key], storedEncoding,
+                        "Unchanged stroke should reuse exact stored encoding (byte-identical)")
     }
 
-    // MARK: - Apply Tests
-
-    func testApplyUpdatesStrokeMap() {
+    func testBuildDesiredStateReencodesWhenMaskAdded() {
         var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
 
-        let date1 = Date(timeIntervalSince1970: 1000)
-        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date1)
-        guard let json1 = encodeStroke(stroke1) else {
-            XCTFail("Failed to encode stroke")
-            return
-        }
-        model.updateFromStrokesMap(["2026-03-25T12:00:00.000Z-AAA": json1])
+        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
+        let storedEncoding = model.strokeMap[key]!
 
-        // Apply: insert a new stroke, remove existing one
-        let date2 = Date(timeIntervalSince1970: 2000)
-        let stroke2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date2)
-        guard let json2 = encodeStroke(stroke2) else {
-            XCTFail("Failed to encode stroke")
-            return
-        }
-        let newKey = "2026-03-25T12:00:01.000Z-BBB"
-        model.apply(inserts: [newKey: json2], removes: ["2026-03-25T12:00:00.000Z-AAA"])
+        // Apply mask to the stroke
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
 
-        XCTAssertEqual(model.strokeMap.count, 1)
-        XCTAssertNotNil(model.strokeMap[newKey])
-        XCTAssertNil(model.strokeMap["2026-03-25T12:00:00.000Z-AAA"])
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [maskedStroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
 
-        // Subsequent diff against the same strokes should produce no changes
-        let result = DittoDrawingModel.computeDiff(currentStrokes: [stroke2], knownCreationDateToKey: model.creationDateToKey)
-        XCTAssertTrue(result.inserts.isEmpty, "No inserts expected after apply")
-        XCTAssertTrue(result.removes.isEmpty, "No removes expected after apply")
+        XCTAssertEqual(result.desired.count, 1)
+        XCTAssertNotEqual(result.desired[key], storedEncoding, "Masked stroke should be re-encoded")
+        XCTAssertTrue(result.newMappings.isEmpty, "Same key should be reused")
+        XCTAssertTrue(result.removes.isEmpty)
     }
 
-    func testApplyKeepsReverseMapsConsistent() {
+    func testBuildDesiredStateReencodesWhenMaskChanged() {
         var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let maskA = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStrokeA = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: maskA)
+        let key = "2026-03-25T12:00:00.000Z"
 
-        let date1 = Date(timeIntervalSince1970: 1000)
-        let date2 = Date(timeIntervalSince1970: 2000)
-        let date3 = Date(timeIntervalSince1970: 3000)
-        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date1)
-        let stroke2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date2)
-        let stroke3 = makeStroke(at: CGPoint(x: 90, y: 90), creationDate: date3)
-        guard let json1 = encodeStroke(stroke1),
-              let json2 = encodeStroke(stroke2),
-              let json3 = encodeStroke(stroke3) else {
-            XCTFail("Failed to encode strokes")
-            return
-        }
+        modelWithKnownStrokes(&model, strokes: [(maskedStrokeA, key)])
+        let storedEncoding = model.strokeMap[key]!
 
-        let key1 = "2026-03-25T12:00:00.000Z-AAA"
-        let key2 = "2026-03-25T12:00:01.000Z-BBB"
-        let key3 = "2026-03-25T12:00:02.000Z-CCC"
+        // Change the mask
+        let maskB = UIBezierPath(ovalIn: CGRect(x: 10, y: 10, width: 100, height: 100))
+        let maskedStrokeB = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: maskB)
 
-        model.updateFromStrokesMap([key1: json1, key2: json2])
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [maskedStrokeB],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
 
-        // Verify reverse map is populated
-        XCTAssertEqual(model.keyToCreationDate[key1], date1)
-        XCTAssertEqual(model.keyToCreationDate[key2], date2)
-
-        // Apply: remove key1, add key3
-        model.apply(inserts: [key3: json3], removes: [key1])
-
-        // Verify both maps are consistent after apply
-        XCTAssertNil(model.keyToCreationDate[key1], "Removed key should be gone from reverse map")
-        XCTAssertNil(model.creationDateToKey[date1], "Removed date should be gone from forward map")
-        XCTAssertEqual(model.keyToCreationDate[key3], date3, "Inserted key should be in reverse map")
-        XCTAssertEqual(model.creationDateToKey[date3], key3, "Inserted date should be in forward map")
-
-        // Existing entry should be untouched
-        XCTAssertEqual(model.keyToCreationDate[key2], date2)
-        XCTAssertEqual(model.creationDateToKey[date2], key2)
+        XCTAssertNotEqual(result.desired[key], storedEncoding, "Changed mask should trigger re-encoding")
     }
 
-    func testRollbackPendingKeysAllowsReSync() {
+    func testBuildDesiredStateReencodesWhenMaskRemoved() {
         var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
+        let key = "2026-03-25T12:00:00.000Z"
 
+        modelWithKnownStrokes(&model, strokes: [(maskedStroke, key)])
+        let storedEncoding = model.strokeMap[key]!
+
+        // Undo: stroke without mask (same creationDate)
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+
+        XCTAssertNotEqual(result.desired[key], storedEncoding, "Mask removal should trigger re-encoding")
+    }
+
+    func testBuildDesiredStateDetectsRemoves() {
+        var model = DittoDrawingModel()
+        let strokeA = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let strokeB = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: Date(timeIntervalSince1970: 2000))
+        let keyA = "2026-03-25T12:00:00.000Z"
+        let keyB = "2026-03-25T12:00:01.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(strokeA, keyA), (strokeB, keyB)])
+
+        // Canvas only has strokeA — strokeB was removed
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [strokeA],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+
+        XCTAssertEqual(result.desired.count, 1)
+        XCTAssertEqual(result.removes, [keyB])
+    }
+
+    func testBuildDesiredStateMixed() {
+        var model = DittoDrawingModel()
+        let strokeA = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let strokeB = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: Date(timeIntervalSince1970: 2000))
+        let keyA = "2026-03-25T12:00:00.000Z"
+        let keyB = "2026-03-25T12:00:01.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(strokeA, keyA), (strokeB, keyB)])
+
+        // Modify A (add mask), remove B, add new stroke C
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedA = PKStroke(ink: strokeA.ink, path: strokeA.path, transform: strokeA.transform, mask: mask)
+        let strokeC = makeStroke(at: CGPoint(x: 90, y: 90), creationDate: Date(timeIntervalSince1970: 3000))
+
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [maskedA, strokeC],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+
+        XCTAssertEqual(result.desired.count, 2, "A (modified) + C (new)")
+        XCTAssertNotNil(result.desired[keyA], "A should use existing key")
+        XCTAssertEqual(result.removes, [keyB], "B should be removed")
+        XCTAssertEqual(result.newMappings.count, 1, "C is the only new stroke")
+    }
+
+    func testBuildDesiredStateEmptyCanvas() {
+        var model = DittoDrawingModel()
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let key = "2026-03-25T12:00:00.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
+
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+
+        XCTAssertTrue(result.desired.isEmpty)
+        XCTAssertEqual(result.removes, [key])
+    }
+
+    // MARK: - Persist / Rollback Tests
+
+    func testPersistPendingPreventsRedundantMappings() {
+        var model = DittoDrawingModel()
         let stroke = makeStroke(at: CGPoint(x: 42, y: 42), creationDate: Date(timeIntervalSince1970: 1000))
 
-        // First diff persists key mappings optimistically
-        let result1 = DittoDrawingModel.computeDiff(currentStrokes: [stroke], knownCreationDateToKey: model.creationDateToKey)
-        model.persistPendingKeys(result1.newMappings)
-        XCTAssertEqual(result1.inserts.count, 1)
+        let result1 = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+        XCTAssertEqual(result1.newMappings.count, 1)
 
-        // Second diff sees stroke as known — no inserts
-        let result2 = DittoDrawingModel.computeDiff(currentStrokes: [stroke], knownCreationDateToKey: model.creationDateToKey)
-        XCTAssertTrue(result2.inserts.isEmpty)
+        _ = model.persistPending(newMappings: result1.newMappings, desired: result1.desired, currentStrokes: [stroke])
 
-        // Rollback simulates a failed transaction
-        model.rollbackPendingKeys(inserts: result1.inserts)
+        let result2 = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+        XCTAssertTrue(result2.newMappings.isEmpty, "Second call should produce no new mappings")
+    }
 
-        // After rollback, the stroke should be detected as new again
-        let result3 = DittoDrawingModel.computeDiff(currentStrokes: [stroke], knownCreationDateToKey: model.creationDateToKey)
-        XCTAssertEqual(result3.inserts.count, 1, "Stroke should be re-detected after rollback")
+    func testRollbackPendingAllowsReDetection() {
+        var model = DittoDrawingModel()
+        let stroke = makeStroke(at: CGPoint(x: 42, y: 42), creationDate: Date(timeIntervalSince1970: 1000))
+
+        let result1 = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+        let oldValues = model.persistPending(newMappings: result1.newMappings, desired: result1.desired, currentStrokes: [stroke])
+
+        model.rollbackPending(oldValues: oldValues, newMappings: result1.newMappings)
+
+        let result2 = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [stroke],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownMaskFingerprints: model.maskFingerprints
+        )
+        XCTAssertEqual(result2.newMappings.count, 1, "Stroke should be re-detected after rollback")
+    }
+
+    // MARK: - Apply Removes Tests
+
+    func testApplyRemovesCleansMaps() {
+        var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
+        let key = "2026-03-25T12:00:00.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(maskedStroke, key)])
+        XCTAssertNotNil(model.maskFingerprints[key])
+
+        model.applyRemoves([key])
+
+        XCTAssertNil(model.strokeMap[key])
+        XCTAssertNil(model.creationDateToKey[date])
+        XCTAssertNil(model.keyToCreationDate[key])
+        XCTAssertNil(model.maskFingerprints[key])
+    }
+
+    func testApplyRemovesLeavesOtherStrokesIntact() {
+        var model = DittoDrawingModel()
+        let strokeA = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let strokeB = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: Date(timeIntervalSince1970: 2000))
+        let keyA = "2026-03-25T12:00:00.000Z"
+        let keyB = "2026-03-25T12:00:01.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(strokeA, keyA), (strokeB, keyB)])
+
+        model.applyRemoves([keyA])
+
+        XCTAssertNil(model.strokeMap[keyA])
+        XCTAssertNotNil(model.strokeMap[keyB], "Other stroke should be untouched")
+        XCTAssertEqual(model.creationDateToKey[Date(timeIntervalSince1970: 2000)], keyB)
+    }
+
+    // MARK: - Update From Strokes Map Tests
+
+    func testUpdateFromStrokesMapPopulatesFingerprints() {
+        var model = DittoDrawingModel()
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
+        let key = "2026-03-25T12:00:00.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(maskedStroke, key)])
+
+        XCTAssertNotNil(model.maskFingerprints[key], "Masked stroke should have a fingerprint")
+    }
+
+    func testUpdateFromStrokesMapNoFingerprintForUnmaskedStroke() {
+        var model = DittoDrawingModel()
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let key = "2026-03-25T12:00:00.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
+
+        XCTAssertNil(model.maskFingerprints[key], "Unmasked stroke should have no fingerprint")
     }
 
     func testUpdateFromStrokesMapClearsStateOnEmptyMap() {
         var model = DittoDrawingModel()
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
 
-        let date1 = Date(timeIntervalSince1970: 1000)
-        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date1)
-        guard let json1 = encodeStroke(stroke1) else {
-            XCTFail("Failed to encode stroke")
-            return
-        }
-
-        model.updateFromStrokesMap(["2026-03-25T12:00:00.000Z-AAA": json1])
+        modelWithKnownStrokes(&model, strokes: [(stroke, "2026-03-25T12:00:00.000Z")])
         XCTAssertEqual(model.strokeMap.count, 1)
 
-        // Updating with a new map replaces state entirely
         model.updateFromStrokesMap([:])
         XCTAssertTrue(model.strokeMap.isEmpty)
         XCTAssertTrue(model.creationDateToKey.isEmpty)
         XCTAssertTrue(model.keyToCreationDate.isEmpty)
+        XCTAssertTrue(model.maskFingerprints.isEmpty)
     }
-
 }

--- a/DrawTogether/DrawTogetherTests/DittoDrawingModelTests.swift
+++ b/DrawTogether/DrawTogetherTests/DittoDrawingModelTests.swift
@@ -76,7 +76,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke1, stroke2],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertEqual(result.desired.count, 2)
@@ -96,7 +96,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertEqual(result.desired.count, 1)
@@ -117,7 +117,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertEqual(result.desired[key], storedEncoding,
@@ -141,7 +141,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [maskedStroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertEqual(result.desired.count, 1)
@@ -169,7 +169,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [maskedStrokeB],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertNotEqual(result.desired[key], storedEncoding, "Changed mask should trigger re-encoding")
@@ -191,7 +191,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertNotEqual(result.desired[key], storedEncoding, "Mask removal should trigger re-encoding")
@@ -211,7 +211,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [strokeA],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertEqual(result.desired.count, 1)
@@ -236,7 +236,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [maskedA, strokeC],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertEqual(result.desired.count, 2, "A (modified) + C (new)")
@@ -256,7 +256,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
 
         XCTAssertTrue(result.desired.isEmpty)
@@ -273,7 +273,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
         XCTAssertEqual(result1.newMappings.count, 1)
 
@@ -283,7 +283,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
         XCTAssertTrue(result2.newMappings.isEmpty, "Second call should produce no new mappings")
     }
@@ -296,7 +296,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
         let oldValues = model.persistPending(newMappings: result1.newMappings, desired: result1.desired, currentStrokes: [stroke])
 
@@ -306,7 +306,7 @@ final class DittoDrawingModelTests: XCTestCase {
             currentStrokes: [stroke],
             knownCreationDateToKey: model.creationDateToKey,
             knownStrokeMap: model.strokeMap,
-            knownMaskFingerprints: model.maskFingerprints
+            knownGroupFingerprints: model.groupFingerprints
         )
         XCTAssertEqual(result2.newMappings.count, 1, "Stroke should be re-detected after rollback")
     }
@@ -322,14 +322,14 @@ final class DittoDrawingModelTests: XCTestCase {
         let key = "2026-03-25T12:00:00.000Z"
 
         modelWithKnownStrokes(&model, strokes: [(maskedStroke, key)])
-        XCTAssertNotNil(model.maskFingerprints[key])
+        XCTAssertNotNil(model.groupFingerprints[key])
 
         model.applyRemoves([key])
 
         XCTAssertNil(model.strokeMap[key])
         XCTAssertNil(model.creationDateToKey[date])
         XCTAssertNil(model.keyToCreationDate[key])
-        XCTAssertNil(model.maskFingerprints[key])
+        XCTAssertNil(model.groupFingerprints[key])
     }
 
     func testApplyRemovesLeavesOtherStrokesIntact() {
@@ -350,26 +350,43 @@ final class DittoDrawingModelTests: XCTestCase {
 
     // MARK: - Update From Strokes Map Tests
 
-    func testUpdateFromStrokesMapPopulatesFingerprints() {
+    func testUpdateFromStrokesMapPopulatesGroupFingerprints() {
         var model = DittoDrawingModel()
-        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
         let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
         let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
-        let key = "2026-03-25T12:00:00.000Z"
+        let unmaskedKey = "2026-03-25T12:00:00.000Z"
+        let maskedKey = "2026-03-25T12:00:01.000Z"
 
-        modelWithKnownStrokes(&model, strokes: [(maskedStroke, key)])
+        modelWithKnownStrokes(&model, strokes: [(stroke, unmaskedKey), (maskedStroke, maskedKey)])
 
-        XCTAssertNotNil(model.maskFingerprints[key], "Masked stroke should have a fingerprint")
+        // Both should have fingerprints (groupFingerprint captures count even without masks)
+        XCTAssertNotNil(model.groupFingerprints[unmaskedKey])
+        XCTAssertNotNil(model.groupFingerprints[maskedKey])
+        // But they should differ (one has a mask, the other doesn't)
+        XCTAssertNotEqual(model.groupFingerprints[unmaskedKey], model.groupFingerprints[maskedKey])
     }
 
-    func testUpdateFromStrokesMapNoFingerprintForUnmaskedStroke() {
+    func testUpdateFromStrokesMapHandlesMultiStrokeGroup() {
         var model = DittoDrawingModel()
-        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: Date(timeIntervalSince1970: 1000))
+        let date = Date(timeIntervalSince1970: 1000)
+        let piece1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let piece2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date)
         let key = "2026-03-25T12:00:00.000Z"
 
-        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
+        guard let encoded = DittoStrokeModel.encodeGroup([piece1, piece2]) else {
+            XCTFail("Group encoding failed")
+            return
+        }
+        model.updateFromStrokesMap([key: encoded])
 
-        XCTAssertNil(model.maskFingerprints[key], "Unmasked stroke should have no fingerprint")
+        XCTAssertEqual(model.creationDateToKey[date], key, "Multi-stroke group should map to one key")
+        XCTAssertEqual(model.keyToCreationDate[key], date)
+        XCTAssertNotNil(model.groupFingerprints[key])
+        // Fingerprint should reflect 2 strokes, not 1
+        let singleFP = DittoStrokeModel.groupFingerprint(for: [piece1])
+        XCTAssertNotEqual(model.groupFingerprints[key], singleFP, "Group fingerprint should reflect both pieces")
     }
 
     func testUpdateFromStrokesMapClearsStateOnEmptyMap() {
@@ -383,6 +400,163 @@ final class DittoDrawingModelTests: XCTestCase {
         XCTAssertTrue(model.strokeMap.isEmpty)
         XCTAssertTrue(model.creationDateToKey.isEmpty)
         XCTAssertTrue(model.keyToCreationDate.isEmpty)
-        XCTAssertTrue(model.maskFingerprints.isEmpty)
+        XCTAssertTrue(model.groupFingerprints.isEmpty)
+    }
+
+    // MARK: - Stroke Split Tests
+
+    func testBuildDesiredStateGroupsSplitStrokes() {
+        var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
+
+        // Simulate split: two strokes with same creationDate
+        let piece1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let piece2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date)
+
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [piece1, piece2],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownGroupFingerprints: model.groupFingerprints
+        )
+
+        XCTAssertEqual(result.desired.count, 1, "Split pieces should be grouped under one key")
+        XCTAssertNotNil(result.desired[key], "Should reuse existing key")
+        XCTAssertTrue(result.removes.isEmpty, "No removes — key is still in use")
+        XCTAssertTrue(result.newMappings.isEmpty, "Same key reused, no new mappings")
+
+        // Verify the encoded value contains both strokes
+        let decoded = DittoStrokeModel.decodeGroup(from: result.desired[key]!)
+        XCTAssertEqual(decoded.count, 2, "Encoded value should contain both split pieces")
+    }
+
+    func testBuildDesiredStateReencodesOnSplit() {
+        var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
+
+        modelWithKnownStrokes(&model, strokes: [(stroke, key)])
+        let storedEncoding = model.strokeMap[key]!
+
+        // Split into two pieces
+        let piece1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let piece2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date)
+
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [piece1, piece2],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownGroupFingerprints: model.groupFingerprints
+        )
+
+        XCTAssertNotEqual(result.desired[key], storedEncoding, "Split should trigger re-encoding")
+    }
+
+    func testBuildDesiredStateHandlesDeleteOfOneSplitPiece() {
+        var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let piece1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let piece2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
+
+        // Populate model with a two-stroke group
+        guard let groupEncoded = DittoStrokeModel.encodeGroup([piece1, piece2]) else {
+            XCTFail("Group encoding failed")
+            return
+        }
+        model.updateFromStrokesMap([key: groupEncoded])
+
+        // User deletes one piece — canvas has only piece1
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [piece1],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownGroupFingerprints: model.groupFingerprints
+        )
+
+        XCTAssertEqual(result.desired.count, 1)
+        XCTAssertNotNil(result.desired[key], "Should reuse existing key")
+        XCTAssertTrue(result.removes.isEmpty, "Key still in use — not a remove")
+
+        // Verify re-encoded as single stroke
+        let decoded = DittoStrokeModel.decodeGroup(from: result.desired[key]!)
+        XCTAssertEqual(decoded.count, 1, "Should encode only the remaining piece")
+    }
+
+    func testBuildDesiredStateHandlesDeleteOfAllSplitPieces() {
+        var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let piece1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let piece2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
+
+        guard let groupEncoded = DittoStrokeModel.encodeGroup([piece1, piece2]) else {
+            XCTFail("Group encoding failed")
+            return
+        }
+        model.updateFromStrokesMap([key: groupEncoded])
+
+        // All pieces deleted
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownGroupFingerprints: model.groupFingerprints
+        )
+
+        XCTAssertTrue(result.desired.isEmpty)
+        XCTAssertEqual(result.removes, [key])
+    }
+
+    func testDrawingReconstructsFlattenedSplitStrokes() {
+        var model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+        let piece1 = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let piece2 = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: date)
+        let key = "2026-03-25T12:00:00.000Z"
+
+        guard let groupEncoded = DittoStrokeModel.encodeGroup([piece1, piece2]) else {
+            XCTFail("Group encoding failed")
+            return
+        }
+        model.updateFromStrokesMap([key: groupEncoded])
+
+        let drawing = model.drawing()
+        XCTAssertEqual(drawing.strokes.count, 2, "drawing() should flatten multi-stroke groups")
+        XCTAssertEqual(drawing.strokes[0].path.first?.location.x ?? 0, 10, accuracy: 1)
+        XCTAssertEqual(drawing.strokes[1].path.first?.location.x ?? 0, 50, accuracy: 1)
+    }
+
+    // MARK: - Timestamp Collision Tests
+
+    func testBuildDesiredStateGroupsUnrelatedStrokesWithSameTimestamp() {
+        let model = DittoDrawingModel()
+        let date = Date(timeIntervalSince1970: 1000)
+
+        // Two unrelated strokes that happen to share a creationDate
+        let strokeA = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        let strokeB = makeStroke(at: CGPoint(x: 90, y: 90), creationDate: date)
+
+        let result = DittoDrawingModel.buildDesiredState(
+            currentStrokes: [strokeA, strokeB],
+            knownCreationDateToKey: model.creationDateToKey,
+            knownStrokeMap: model.strokeMap,
+            knownGroupFingerprints: model.groupFingerprints
+        )
+
+        XCTAssertEqual(result.desired.count, 1, "Both strokes should be grouped under one key")
+        XCTAssertEqual(result.newMappings.count, 1, "One new key for the shared date")
+
+        // Verify both strokes are preserved in the encoded value
+        let key = result.newMappings[0].key
+        let decoded = DittoStrokeModel.decodeGroup(from: result.desired[key]!)
+        XCTAssertEqual(decoded.count, 2, "Both strokes should survive the round-trip")
+        XCTAssertEqual(decoded[0].path.first?.location.x ?? 0, 10, accuracy: 1)
+        XCTAssertEqual(decoded[1].path.first?.location.x ?? 0, 90, accuracy: 1)
     }
 }

--- a/DrawTogether/DrawTogetherTests/DittoStrokeModelTests.swift
+++ b/DrawTogether/DrawTogetherTests/DittoStrokeModelTests.swift
@@ -27,8 +27,8 @@ final class DittoStrokeModelTests: XCTestCase {
     func testRoundTripPreservesContent() {
         let originalStroke = makeStroke(at: CGPoint(x: 42, y: 42))
 
-        guard let json = DittoStrokeModel.encode(originalStroke),
-              let roundTrippedStroke = DittoStrokeModel.decode(from: json) else {
+        guard let encoded = DittoStrokeModel.encode(originalStroke),
+              let roundTrippedStroke = DittoStrokeModel.decode(from: encoded) else {
             XCTFail("Round-trip encoding/decoding failed")
             return
         }
@@ -39,9 +39,59 @@ final class DittoStrokeModelTests: XCTestCase {
         XCTAssertEqual(roundTrippedStroke.ink.inkType, originalStroke.ink.inkType)
     }
 
-    func testDecodeReturnsNilForInvalidJSON() {
-        XCTAssertNil(DittoStrokeModel.decode(from: "not valid json"))
-        XCTAssertNil(DittoStrokeModel.decode(from: "{}"))
+    func testRoundTripPreservesMask() {
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let stroke = makeStroke(at: CGPoint(x: 42, y: 42))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
+
+        guard let encoded = DittoStrokeModel.encode(maskedStroke),
+              let decoded = DittoStrokeModel.decode(from: encoded) else {
+            XCTFail("Round-trip encoding/decoding failed")
+            return
+        }
+
+        XCTAssertNotNil(decoded.mask, "Decoded stroke should have a mask")
+        let decodedBounds = decoded.mask!.bounds
+        XCTAssertEqual(decodedBounds.origin.x, mask.bounds.origin.x, accuracy: 1)
+        XCTAssertEqual(decodedBounds.origin.y, mask.bounds.origin.y, accuracy: 1)
+        XCTAssertEqual(decodedBounds.size.width, mask.bounds.size.width, accuracy: 1)
+        XCTAssertEqual(decodedBounds.size.height, mask.bounds.size.height, accuracy: 1)
+    }
+
+    func testDecodeReturnsNilForInvalidInput() {
+        XCTAssertNil(DittoStrokeModel.decode(from: "not valid base64!@#"))
+        XCTAssertNil(DittoStrokeModel.decode(from: ""))
+        // Valid base64 but not a PKDrawing
+        XCTAssertNil(DittoStrokeModel.decode(from: "aGVsbG8="))
+    }
+
+    // MARK: - Mask Fingerprint Tests
+
+    func testMaskFingerprintNilForNoMask() {
+        let stroke = makeStroke()
+        XCTAssertNil(DittoStrokeModel.maskFingerprint(for: stroke))
+    }
+
+    func testMaskFingerprintStableForSameMask() {
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let stroke = PKStroke(ink: PKInk(.pen, color: .black), path: makeStroke().path, transform: .identity, mask: mask)
+        let fp1 = DittoStrokeModel.maskFingerprint(for: stroke)
+        let fp2 = DittoStrokeModel.maskFingerprint(for: stroke)
+        XCTAssertNotNil(fp1)
+        XCTAssertEqual(fp1, fp2, "Same mask should produce identical fingerprints")
+    }
+
+    func testMaskFingerprintDiffersForDifferentMasks() {
+        let base = makeStroke()
+        let maskA = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskB = UIBezierPath(ovalIn: CGRect(x: 10, y: 10, width: 100, height: 100))
+        let strokeA = PKStroke(ink: base.ink, path: base.path, transform: base.transform, mask: maskA)
+        let strokeB = PKStroke(ink: base.ink, path: base.path, transform: base.transform, mask: maskB)
+        let fpA = DittoStrokeModel.maskFingerprint(for: strokeA)
+        let fpB = DittoStrokeModel.maskFingerprint(for: strokeB)
+        XCTAssertNotNil(fpA)
+        XCTAssertNotNil(fpB)
+        XCTAssertNotEqual(fpA, fpB, "Different masks should produce different fingerprints")
     }
 
     // MARK: - Key Generation Tests

--- a/DrawTogether/DrawTogetherTests/DittoStrokeModelTests.swift
+++ b/DrawTogether/DrawTogetherTests/DittoStrokeModelTests.swift
@@ -24,45 +24,15 @@ final class DittoStrokeModelTests: XCTestCase {
 
     // MARK: - Encode/Decode Tests
 
-    func testRoundTripPreservesContent() {
-        let originalStroke = makeStroke(at: CGPoint(x: 42, y: 42))
-
-        guard let encoded = DittoStrokeModel.encode(originalStroke),
-              let roundTrippedStroke = DittoStrokeModel.decode(from: encoded) else {
-            XCTFail("Round-trip encoding/decoding failed")
-            return
-        }
-
-        XCTAssertEqual(roundTrippedStroke.path.count, originalStroke.path.count)
-        XCTAssertEqual(roundTrippedStroke.path.first?.location.x ?? 0, 42, accuracy: 1)
-        XCTAssertEqual(roundTrippedStroke.path.first?.location.y ?? 0, 42, accuracy: 1)
-        XCTAssertEqual(roundTrippedStroke.ink.inkType, originalStroke.ink.inkType)
-    }
-
-    func testRoundTripPreservesMask() {
-        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
-        let stroke = makeStroke(at: CGPoint(x: 42, y: 42))
-        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
-
-        guard let encoded = DittoStrokeModel.encode(maskedStroke),
-              let decoded = DittoStrokeModel.decode(from: encoded) else {
-            XCTFail("Round-trip encoding/decoding failed")
-            return
-        }
-
-        XCTAssertNotNil(decoded.mask, "Decoded stroke should have a mask")
-        let decodedBounds = decoded.mask!.bounds
-        XCTAssertEqual(decodedBounds.origin.x, mask.bounds.origin.x, accuracy: 1)
-        XCTAssertEqual(decodedBounds.origin.y, mask.bounds.origin.y, accuracy: 1)
-        XCTAssertEqual(decodedBounds.size.width, mask.bounds.size.width, accuracy: 1)
-        XCTAssertEqual(decodedBounds.size.height, mask.bounds.size.height, accuracy: 1)
-    }
-
-    func testDecodeReturnsNilForInvalidInput() {
-        XCTAssertNil(DittoStrokeModel.decode(from: "not valid base64!@#"))
-        XCTAssertNil(DittoStrokeModel.decode(from: ""))
+    func testDecodeGroupReturnsEmptyForInvalidInput() {
+        XCTAssertTrue(DittoStrokeModel.decodeGroup(from: "not valid base64!@#").isEmpty)
+        XCTAssertTrue(DittoStrokeModel.decodeGroup(from: "").isEmpty)
         // Valid base64 but not a PKDrawing
-        XCTAssertNil(DittoStrokeModel.decode(from: "aGVsbG8="))
+        XCTAssertTrue(DittoStrokeModel.decodeGroup(from: "aGVsbG8=").isEmpty)
+    }
+
+    func testEncodeGroupReturnsNilForEmptyArray() {
+        XCTAssertNil(DittoStrokeModel.encodeGroup([]))
     }
 
     // MARK: - Mask Fingerprint Tests
@@ -92,6 +62,43 @@ final class DittoStrokeModelTests: XCTestCase {
         XCTAssertNotNil(fpA)
         XCTAssertNotNil(fpB)
         XCTAssertNotEqual(fpA, fpB, "Different masks should produce different fingerprints")
+    }
+
+    // MARK: - Group Fingerprint Tests
+
+    func testGroupFingerprintChangesWithStrokeCount() {
+        let stroke = makeStroke()
+        let fp1 = DittoStrokeModel.groupFingerprint(for: [stroke])
+        let fp2 = DittoStrokeModel.groupFingerprint(for: [stroke, stroke])
+        XCTAssertNotEqual(fp1, fp2, "Different stroke counts should produce different fingerprints")
+    }
+
+    func testGroupFingerprintStableForSameGroup() {
+        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10))
+        let stroke2 = makeStroke(at: CGPoint(x: 50, y: 50))
+        let fp1 = DittoStrokeModel.groupFingerprint(for: [stroke1, stroke2])
+        let fp2 = DittoStrokeModel.groupFingerprint(for: [stroke1, stroke2])
+        XCTAssertEqual(fp1, fp2, "Same group should produce identical fingerprints")
+    }
+
+    func testGroupFingerprintChangesWhenMaskAdded() {
+        let stroke = makeStroke()
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
+
+        let fpBefore = DittoStrokeModel.groupFingerprint(for: [stroke])
+        let fpAfter = DittoStrokeModel.groupFingerprint(for: [maskedStroke])
+        XCTAssertNotEqual(fpBefore, fpAfter, "Adding a mask should change the group fingerprint")
+    }
+
+    func testGroupFingerprintSensitiveToOrder() {
+        let stroke1 = makeStroke(at: CGPoint(x: 10, y: 10))
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let stroke2 = PKStroke(ink: stroke1.ink, path: makeStroke(at: CGPoint(x: 50, y: 50)).path, transform: .identity, mask: mask)
+
+        let fpAB = DittoStrokeModel.groupFingerprint(for: [stroke1, stroke2])
+        let fpBA = DittoStrokeModel.groupFingerprint(for: [stroke2, stroke1])
+        XCTAssertNotEqual(fpAB, fpBA, "Different stroke order should produce different fingerprints")
     }
 
     // MARK: - Key Generation Tests

--- a/DrawTogether/DrawTogetherTests/DrawingSyncCoordinatorTests.swift
+++ b/DrawTogether/DrawTogetherTests/DrawingSyncCoordinatorTests.swift
@@ -166,6 +166,121 @@ final class DrawingSyncCoordinatorTests: XCTestCase {
         await waitForModel(strokeCount: 2)
     }
 
+    // MARK: - Modified Stroke Tests
+
+    func testModifiedStrokeSyncsToDitto() async throws {
+        // Sync an unmasked stroke
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        canvasView.drawing = PKDrawing(strokes: [stroke])
+        try await triggerSyncAndWaitForDitto(expectedStrokeCount: 1)
+
+        // Apply a mask (simulating bitmap eraser) and sync again
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
+        canvasView.drawing = PKDrawing(strokes: [maskedStroke])
+
+        // Wait for the model to update with the masked stroke
+        let exp = expectation(description: "Model updated with masked stroke")
+        coordinator.onModelUpdate = { [weak self] in
+            guard let self else { return }
+            // Check that the stored stroke now has a mask
+            if let key = self.coordinator.model.creationDateToKey[date],
+               let encoded = self.coordinator.model.strokeMap[key],
+               let decoded = DittoStrokeModel.decode(from: encoded),
+               decoded.mask != nil {
+                exp.fulfill()
+                self.coordinator.onModelUpdate = nil
+            }
+        }
+        coordinator.canvasViewDrawingDidChange(canvasView)
+        await fulfillment(of: [exp], timeout: 5.0)
+    }
+
+    func testModifiedStrokeFromRemoteUpdatesLocal() async throws {
+        // Sync a stroke through the coordinator first
+        let date = Date(timeIntervalSince1970: 1000)
+        let stroke = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: date)
+        canvasView.drawing = PKDrawing(strokes: [stroke])
+        try await triggerSyncAndWaitForDitto(expectedStrokeCount: 1)
+
+        // Directly write a masked version into Ditto (simulating remote peer)
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
+        guard let maskedEncoded = DittoStrokeModel.encode(maskedStroke) else {
+            XCTFail("Failed to encode masked stroke")
+            return
+        }
+        let key = coordinator.model.creationDateToKey[date]!
+        let doc: [String: Any] = ["_id": coordinator.model.drawingID, "strokes": [key: maskedEncoded]]
+        try await ditto.store.execute(
+            query: "INSERT INTO drawings VALUES (:doc) ON ID CONFLICT DO UPDATE",
+            arguments: ["doc": doc]
+        )
+
+        // Wait for the coordinator's observer to update the model with the masked stroke
+        let exp = expectation(description: "Model updated with remote masked stroke")
+        coordinator.onModelUpdate = { [weak self] in
+            guard let self else { return }
+            if let encoded = self.coordinator.model.strokeMap[key],
+               let decoded = DittoStrokeModel.decode(from: encoded),
+               decoded.mask != nil {
+                exp.fulfill()
+                self.coordinator.onModelUpdate = nil
+            }
+        }
+        await fulfillment(of: [exp], timeout: 5.0)
+
+        // Verify fingerprint was populated
+        XCTAssertNotNil(coordinator.model.maskFingerprints[key])
+    }
+
+    func testMixedInsertUpdateAndRemove() async throws {
+        // Sync strokes A and B
+        let dateA = Date(timeIntervalSince1970: 1000)
+        let dateB = Date(timeIntervalSince1970: 2000)
+        let strokeA = makeStroke(at: CGPoint(x: 10, y: 10), creationDate: dateA)
+        let strokeB = makeStroke(at: CGPoint(x: 50, y: 50), creationDate: dateB)
+        canvasView.drawing = PKDrawing(strokes: [strokeA, strokeB])
+        try await triggerSyncAndWaitForDitto(expectedStrokeCount: 2)
+
+        let keyA = coordinator.model.creationDateToKey[dateA]!
+        let keyB = coordinator.model.creationDateToKey[dateB]!
+
+        // Modify A (add mask), remove B, add C
+        let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let maskedA = PKStroke(ink: strokeA.ink, path: strokeA.path, transform: strokeA.transform, mask: mask)
+        let dateC = Date(timeIntervalSince1970: 3000)
+        let strokeC = makeStroke(at: CGPoint(x: 90, y: 90), creationDate: dateC)
+        canvasView.drawing = PKDrawing(strokes: [maskedA, strokeC])
+
+        // Wait for Ditto to reflect: B removed, so keyB should be gone
+        let exp = expectation(description: "Ditto has mixed changes applied")
+        let observer = try ditto.store.registerObserver(
+            query: "SELECT * FROM drawings WHERE _id = :id",
+            arguments: ["id": coordinator.model.drawingID]
+        ) { result in
+            guard let item = result.items.first,
+                  let strokes = item.value["strokes"] as? [String: Any] else { return }
+            // B should be removed and we should have exactly 2 strokes
+            if strokes[keyB] == nil && strokes.count == 2 {
+                exp.fulfill()
+            }
+        }
+        coordinator.canvasViewDrawingDidChange(canvasView)
+        await fulfillment(of: [exp], timeout: 5.0)
+        observer.cancel()
+
+        // Verify A has a mask
+        let dittoMap = try await queryStrokesMap()
+        if let encodedA = dittoMap[keyA] as? String,
+           let decodedA = DittoStrokeModel.decode(from: encodedA) {
+            XCTAssertNotNil(decodedA.mask, "Stroke A should have a mask after modification")
+        } else {
+            XCTFail("Stroke A not found or failed to decode")
+        }
+    }
+
     // MARK: - Round-Trip Tests
 
     func testFullRoundTrip() async throws {

--- a/DrawTogether/DrawTogetherTests/DrawingSyncCoordinatorTests.swift
+++ b/DrawTogether/DrawTogetherTests/DrawingSyncCoordinatorTests.swift
@@ -149,7 +149,8 @@ final class DrawingSyncCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(coordinator.model.strokeMap.count, 1)
 
-        // Simulate a remote insert directly into Ditto
+        // Simulate a remote peer inserting a stroke by writing directly to Ditto
+        // (bypasses the coordinator to mimic data arriving from another device)
         let remoteStroke = makeStroke(at: CGPoint(x: 200, y: 200), creationDate: Date(timeIntervalSince1970: 5000))
         guard let remoteJSON = DittoStrokeModel.encode(remoteStroke) else {
             XCTFail("Failed to encode remote stroke")
@@ -186,11 +187,12 @@ final class DrawingSyncCoordinatorTests: XCTestCase {
             guard let self else { return }
             // Check that the stored stroke now has a mask
             if let key = self.coordinator.model.creationDateToKey[date],
-               let encoded = self.coordinator.model.strokeMap[key],
-               let decoded = DittoStrokeModel.decode(from: encoded),
-               decoded.mask != nil {
-                exp.fulfill()
-                self.coordinator.onModelUpdate = nil
+               let encoded = self.coordinator.model.strokeMap[key] {
+                let decoded = DittoStrokeModel.decodeGroup(from: encoded)
+                if decoded.first?.mask != nil {
+                    exp.fulfill()
+                    self.coordinator.onModelUpdate = nil
+                }
             }
         }
         coordinator.canvasViewDrawingDidChange(canvasView)
@@ -204,7 +206,8 @@ final class DrawingSyncCoordinatorTests: XCTestCase {
         canvasView.drawing = PKDrawing(strokes: [stroke])
         try await triggerSyncAndWaitForDitto(expectedStrokeCount: 1)
 
-        // Directly write a masked version into Ditto (simulating remote peer)
+        // Simulate a remote peer applying a bitmap eraser by writing a masked stroke
+        // directly to Ditto (bypasses the coordinator to mimic data arriving from another device)
         let mask = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 50, height: 50))
         let maskedStroke = PKStroke(ink: stroke.ink, path: stroke.path, transform: stroke.transform, mask: mask)
         guard let maskedEncoded = DittoStrokeModel.encode(maskedStroke) else {
@@ -222,17 +225,18 @@ final class DrawingSyncCoordinatorTests: XCTestCase {
         let exp = expectation(description: "Model updated with remote masked stroke")
         coordinator.onModelUpdate = { [weak self] in
             guard let self else { return }
-            if let encoded = self.coordinator.model.strokeMap[key],
-               let decoded = DittoStrokeModel.decode(from: encoded),
-               decoded.mask != nil {
-                exp.fulfill()
-                self.coordinator.onModelUpdate = nil
+            if let encoded = self.coordinator.model.strokeMap[key] {
+                let decoded = DittoStrokeModel.decodeGroup(from: encoded)
+                if decoded.first?.mask != nil {
+                    exp.fulfill()
+                    self.coordinator.onModelUpdate = nil
+                }
             }
         }
         await fulfillment(of: [exp], timeout: 5.0)
 
         // Verify fingerprint was populated
-        XCTAssertNotNil(coordinator.model.maskFingerprints[key])
+        XCTAssertNotNil(coordinator.model.groupFingerprints[key])
     }
 
     func testMixedInsertUpdateAndRemove() async throws {
@@ -273,11 +277,12 @@ final class DrawingSyncCoordinatorTests: XCTestCase {
 
         // Verify A has a mask
         let dittoMap = try await queryStrokesMap()
-        if let encodedA = dittoMap[keyA] as? String,
-           let decodedA = DittoStrokeModel.decode(from: encodedA) {
-            XCTAssertNotNil(decodedA.mask, "Stroke A should have a mask after modification")
+        if let encodedA = dittoMap[keyA] as? String {
+            let decodedA = DittoStrokeModel.decodeGroup(from: encodedA)
+            XCTAssertFalse(decodedA.isEmpty, "Stroke A should decode successfully")
+            XCTAssertNotNil(decodedA.first?.mask, "Stroke A should have a mask after modification")
         } else {
-            XCTFail("Stroke A not found or failed to decode")
+            XCTFail("Stroke A not found in Ditto")
         }
     }
 
@@ -300,4 +305,5 @@ final class DrawingSyncCoordinatorTests: XCTestCase {
         // 4. Verify model has one
         XCTAssertEqual(coordinator.model.drawing().strokes.count, 1)
     }
+
 }


### PR DESCRIPTION
## Summary

Fixes #8. Syncs bitmap eraser changes by detecting both mask modifications and stroke splits.

### Two bitmap eraser behaviors

1. **Mask without splitting** — PencilKit sets a `mask` on the stroke without changing `creationDate`. Detected via deterministic `NSKeyedArchiver` fingerprinting of the mask.
2. **Split into pieces** — PencilKit splits a stroke into 2+ pieces sharing the same `creationDate`. All pieces are packed into a single multi-stroke `PKDrawing` under one Ditto key, so no data is lost.

### Change detection

`buildDesiredState` groups canvas strokes by `creationDate` and computes a group fingerprint (stroke count + ordered mask data). Unchanged groups reuse their stored encoding byte-for-byte; groups with fingerprint changes (mask edit, split, or piece deletion) get re-encoded.

### Ditto sync

Uses `DO UPDATE_LOCAL_DIFF` so unchanged strokes (identical stored bytes) produce no diff and skip replication. Avoids concurrent write conflicts from non-deterministic re-encoding.

### Edge cases

- **Timestamp collisions**: if two unrelated strokes share a `creationDate`, they're grouped together — both survive (previously one was silently lost).
- **Concurrent splits**: LWW resolves cleanly — one peer's entire split wins, no chimera of mixed pieces.

### Schema migration

Because we haven't solved #11 yet, we can cheat! This PR bumps the default `drawingID` from `"1"` to `"2"` so new clients start a fresh document using the new Ditto schema.

## Test plan

- [x] Draw strokes, bitmap-erase through a stroke, verify both halves persist across sync
- [x] Bitmap-erase a stroke partially (mask only), verify erased area persists
- [x] Further split an already-split piece, verify all pieces survive
- [x] Undo bitmap erase, verify reversion syncs
- [x] Verify vector eraser still works
- [x] Draw on two devices simultaneously, verify no unintended overwrites