### PR TITLE
Enable Dependabot for Ditto SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: swift
+    directory: /DrawTogether
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-name: github.com/getditto/dittoswiftpackage


### PR DESCRIPTION
Adds a weekly Dependabot check for the Xcode project’s Swift packages, scoped to DittoSwiftPackage so future Ditto SDK releases are opened as pull requests.