### PR TITLE
Explain stroke-level sync architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Copy this file to .env and use the connection details from the Ditto Portal.
 DITTO_DATABASE_ID=your-database-id
 DITTO_SERVER_URL=https://your-server-url
 DITTO_PLAYGROUND_TOKEN=your-playground-token

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# Copy this file from ".env.sample" to ".env", then fill in these values
-# A Ditto AppID and Playground token can be obtained from https://portal.ditto.live
-DITTO_APP_ID=""
-DITTO_PLAYGROUND_TOKEN=""
-DITTO_AUTH_URL=""

--- a/DrawTogether/DrawTogether/Drawing/DittoStrokeModel.swift
+++ b/DrawTogether/DrawTogether/Drawing/DittoStrokeModel.swift
@@ -18,8 +18,9 @@ import PencilKit
 /// strokes produces different bytes each time. Callers must store and reuse encoded values
 /// rather than re-encoding for comparison. Use `groupFingerprint(for:)` for change detection.
 ///
-/// Keys are ISO8601 timestamps derived from `PKStrokePath.creationDate`, which PencilKit assigns
-/// uniquely when a stroke is drawn, giving deterministic and chronologically sortable keys.
+/// Keys are ISO8601 timestamps derived from `PKStrokePath.creationDate`, giving deterministic
+/// and chronologically sortable keys. Callers group equal creation dates before encoding so a
+/// collision does not drop a stroke.
 struct DittoStrokeModel {
 
     /// Encodes a PKStroke as a base64 string via `PKDrawing.dataRepresentation()`.
@@ -75,11 +76,9 @@ struct DittoStrokeModel {
 
     /// Generates a deterministic, sortable key from a stroke's creation date.
     /// ISO8601 with fractional seconds (millisecond precision) ensures lexicographic sort = chronological order.
-    /// Collisions require two strokes created within the same millisecond, which is practically impossible:
-    /// each stroke requires physical drawing input that far exceeds 1ms, and PencilKit serializes stroke
-    /// creation on the main thread. If a collision does occur (or PencilKit produces multiple strokes with
-    /// the same `creationDate`, e.g., bitmap eraser splits), the strokes are grouped and encoded together
-    /// under one key via `encodeGroup`, so no data is lost.
+    /// If multiple strokes share the same millisecond, either because their creation dates collide or
+    /// because PencilKit split a stroke during bitmap erasing, they are encoded together under one key
+    /// via `encodeGroup`.
     static func generateKey(for date: Date) -> String {
         ISO8601DateFormatter.fractional.string(from: date)
     }

--- a/DrawTogether/DrawTogether/Drawing/DrawingSyncCoordinator.swift
+++ b/DrawTogether/DrawTogether/Drawing/DrawingSyncCoordinator.swift
@@ -11,7 +11,8 @@ import DittoSwift
 
 /// Coordinates bidirectional sync between a PKCanvasView and Ditto.
 /// Observes local drawing changes, builds the desired state, and syncs to Ditto via transactions.
-/// Observes remote Ditto changes and rebuilds the local drawing, preserving uncommitted local strokes.
+/// Observes remote Ditto changes and rebuilds the local drawing, preserving newly created local
+/// strokes that are not in the synchronized model yet.
 class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
     private var parent: DrawingCanvasView
     var toolPicker: PKToolPicker?
@@ -160,7 +161,7 @@ class DrawingSyncCoordinator: NSObject, PKCanvasViewDelegate {
         // Cancel any pending sync — will be re-triggered if there are uncommitted local strokes
         syncTask?.cancel()
 
-        // Preserve uncommitted local strokes from the canvas (not the binding, which may be stale)
+        // Preserve newly created local strokes from the canvas (not the binding, which may be stale)
         let knownDates = Set(model.creationDateToKey.keys)
         let currentStrokes = canvasView?.drawing.strokes ?? parent.drawing.strokes
         let uncommittedStrokes = currentStrokes.filter { !knownDates.contains($0.path.creationDate) }

--- a/README.md
+++ b/README.md
@@ -123,4 +123,6 @@ Copy `.env.example` to `.env`, fill in the Ditto database ID, server URL, and
 playground token, then open `DrawTogether/DrawTogether.xcodeproj`. The build
 generates an ignored `Env.swift` from that local file.
 
-This is open source, so feel free to open an issue or send a PR.
+## Contributing
+
+This is open source so feel free to contribute if you want!

--- a/README.md
+++ b/README.md
@@ -1,12 +1,122 @@
 # DrawTogether
-A Ditto-backed app for collaborative drawing, based on Apple's PencilKit.
 
-This is a "just for fun" side project that I thought would be a lot easier than it turned out to be - PencilKit makes a lot of single-write assumptions and optimizations - which turned this into a really interesting (if complicated) case study in utilizing Ditto's CRDT-based deterministic conflict resolution with multiple writers. 
+DrawTogether is a collaborative iOS drawing app built with
+[PencilKit](https://developer.apple.com/documentation/pencilkit) and
+[Ditto](https://docs.ditto.live/). Each device writes to its
+[local Ditto store](https://docs.ditto.live/key-concepts/accessing-data), and
+Ditto syncs those changes when the devices can communicate.
 
-To learn more about Ditto, see the docs [here](https://docs.ditto.live/).
+PencilKit represents a canvas as one `PKDrawing` designed for a single editing
+session. Collaborative drawing needs conflict resolution below the complete
+drawing, so DrawTogether uses the individual stroke as that boundary.
 
-To learn more about PencilKit, see the docs [here](https://developer.apple.com/documentation/pencilkit).
+## Data model
 
-To run the app, copy `.env.example` to `.env` and fill in the Ditto database ID, server URL, and playground token. The Xcode build generates `Env.swift` from that local file.
+Storing a serialized `PKDrawing` in one field would make the entire canvas one
+last-write-wins value. Separate strokes created concurrently would compete as
+complete drawing updates. DrawTogether uses one
+[Ditto document](https://docs.ditto.live/key-concepts/document-model) per drawing
+and stores each stroke in a map:
 
-This is open source so feel free to contribute if you want!
+```json
+{
+  "_id": "drawing-1",
+  "name": "Design notes",
+  "strokes": {
+    "2026-03-25T16:20:14.127Z": "<base64 PKDrawing>",
+    "2026-03-25T16:20:16.842Z": "<base64 PKDrawing>"
+  }
+}
+```
+
+`strokes` is an
+[add-wins Ditto map](https://docs.ditto.live/dql/types-and-definitions#map-operations).
+Each key merges independently, so concurrent additions from different peers are
+preserved. The base64 value under each key is a
+[register](https://docs.ditto.live/dql/types-and-definitions#register-operations),
+which moves the last-write-wins boundary from the whole canvas down to one
+stroke.
+
+For example:
+
+```text
+Peer 1 adds stroke A            Peer 2 adds stroke B
+strokes["...14.127Z"] = A       strokes["...16.842Z"] = B
+
+                         sync
+                          │
+                          ▼
+             strokes = { A, B }
+```
+
+The peers can receive those operations in either order and still converge on
+both strokes. If both peers change the same stroke, Ditto deterministically
+selects one complete encoded version. No separate conflict resolver is needed;
+the document shape defines the merge behavior.
+
+This follows Ditto's
+[map-keyed collection pattern](https://docs.ditto.live/best-practices/conflict-resolution-patterns).
+Ditto's [Syncing Data](https://docs.ditto.live/key-concepts/syncing-data)
+documentation explains the add-wins map and last-write-wins register behavior
+used here.
+
+## PencilKit serialization
+
+Each map key comes from `PKStrokePath.creationDate`. Its ISO 8601 representation
+is stable and sortable, so the same value provides stroke identity and z-order
+when rebuilding the canvas.
+
+Each map value uses PencilKit's native `PKDrawing.dataRepresentation()` encoded
+as base64. It normally contains one `PKStroke`, so the app keeps PencilKit's ink,
+path, transform, and eraser mask without maintaining another vector format.
+
+PencilKit's bitmap eraser can change a stroke's mask or split one stroke into
+several pieces. Those pieces keep the original creation date, so DrawTogether
+groups them under the same Ditto key and encodes them together. A fingerprint
+detects mask and split changes while letting unchanged groups reuse their
+existing encoding.
+
+## Synchronization
+
+`DrawingSyncCoordinator` is the bridge between `PKCanvasView` and the Ditto
+document:
+
+1. It debounces canvas callbacks for 100 milliseconds.
+2. `DittoDrawingModel` groups the current strokes by creation date and compares
+   them with the last synchronized state.
+3. It writes new and changed entries with `ON ID CONFLICT DO
+   UPDATE_LOCAL_DIFF`, and explicitly `UNSET`s removed entries in the same
+   [transaction](https://docs.ditto.live/sdk/latest/crud/transactions).
+4. A Ditto store observer receives the local or remote document, decodes the
+   entries, sorts the keys, and rebuilds the `PKDrawing`.
+
+[`UPDATE_LOCAL_DIFF`](https://docs.ditto.live/dql/insert#do-update-local-diff)
+means the coordinator can submit its current stroke map without rewriting and
+replicating values that did not change.
+[`UNSET`](https://docs.ditto.live/dql/update#deleting-fields) tells Ditto that an
+omitted stroke was intentionally removed.
+
+The app uses a
+[sync subscription](https://docs.ditto.live/sdk/latest/sync/syncing-data) for
+the `drawings` collection and a separate
+[store observer](https://docs.ditto.live/sdk/latest/crud/observing-data-changes)
+for each open drawing. The subscription brings documents into the local store.
+The observer turns changes in that store back into UI state.
+
+## Implementation
+
+- [`DrawingSyncCoordinator.swift`](DrawTogether/DrawTogether/Drawing/DrawingSyncCoordinator.swift)
+  owns the PencilKit-to-Ditto sync loop.
+- [`DittoDrawingModel.swift`](DrawTogether/DrawTogether/Drawing/DittoDrawingModel.swift)
+  calculates map updates and rebuilds a drawing.
+- [`DittoStrokeModel.swift`](DrawTogether/DrawTogether/Drawing/DittoStrokeModel.swift)
+  handles encoding, grouping, fingerprints, and keys.
+- [`DrawTogetherTests`](DrawTogether/DrawTogetherTests) covers round trips,
+  eraser splits, removals, observers, and DQL transactions against local Ditto
+  instances.
+
+## Configuration
+
+Copy `.env.example` to `.env`, fill in the Ditto database ID, server URL, and
+playground token, then open `DrawTogether/DrawTogether.xcodeproj`. The build
+generates an ignored `Env.swift` from that local file.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # DrawTogether
 
-DrawTogether is a collaborative iOS drawing app built with
+DrawTogether is a just-for-fun collaborative iOS drawing app built with
 [PencilKit](https://developer.apple.com/documentation/pencilkit) and
-[Ditto](https://docs.ditto.live/). Each device writes to its
-[local Ditto store](https://docs.ditto.live/key-concepts/accessing-data), and
-Ditto syncs those changes when the devices can communicate.
+[Ditto](https://docs.ditto.live/). It focuses on two people editing the same
+PencilKit canvas at the same time.
 
-DrawTogether is a just-for-fun side project focused on two people editing the
-same PencilKit canvas at the same time. PencilKit has strong single-writer
-assumptions, while Ditto uses CRDTs to merge concurrent changes
-deterministically. The app bridges those models by making the individual stroke
-the conflict boundary.
+Each device writes to its
+[local Ditto store](https://docs.ditto.live/key-concepts/accessing-data), and
+Ditto syncs those changes when the devices can communicate. PencilKit has strong
+single-writer assumptions, while Ditto uses CRDTs to merge concurrent changes
+deterministically. DrawTogether connects those models by using the individual
+stroke as the conflict boundary.
 
 ## Data model
 
@@ -33,9 +33,9 @@ and stores each stroke in a map:
 
 `strokes` is an
 [add-wins Ditto map](https://docs.ditto.live/dql/types-and-definitions#map-operations).
-Ditto can merge changes to each key without replacing other entries, so
-concurrent additions from different peers are preserved. The base64 value under
-each key is a
+Each key is a separate entry in that map, so Ditto can merge changes to one key
+without replacing the others. Concurrent additions from different peers are
+preserved. The base64 value under each key is a
 [register](https://docs.ditto.live/dql/types-and-definitions#register-operations),
 which moves the last-write-wins boundary from the whole canvas down to one
 stroke.
@@ -57,11 +57,10 @@ both strokes. If both peers change the same stroke, Ditto deterministically
 selects one complete encoded version. No separate conflict resolver is needed;
 the document shape defines the merge behavior.
 
-This follows Ditto's
-[map-keyed collection pattern](https://docs.ditto.live/best-practices/conflict-resolution-patterns).
-Ditto's [Syncing Data](https://docs.ditto.live/key-concepts/syncing-data)
-documentation explains the add-wins map and last-write-wins register behavior
-used here.
+Ditto covers this model in
+[Conflict Resolution Patterns](https://docs.ditto.live/best-practices/conflict-resolution-patterns)
+and the underlying convergence behavior in
+[Syncing Data](https://docs.ditto.live/key-concepts/syncing-data).
 
 ## PencilKit serialization
 
@@ -90,8 +89,8 @@ document:
 3. It writes new and changed entries with `ON ID CONFLICT DO
    UPDATE_LOCAL_DIFF`, and explicitly `UNSET`s removed entries in the same
    [transaction](https://docs.ditto.live/sdk/latest/crud/transactions).
-4. A Ditto store observer receives the local or remote document, decodes the
-   entries, sorts the keys, and rebuilds the `PKDrawing`.
+4. A Ditto store observer reacts when the document changes in the local store,
+   decodes its entries, sorts the keys, and rebuilds the `PKDrawing`.
 
 [`UPDATE_LOCAL_DIFF`](https://docs.ditto.live/dql/insert#do-update-local-diff)
 means the coordinator can submit its current stroke map without rewriting and

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ DrawTogether is a collaborative iOS drawing app built with
 [local Ditto store](https://docs.ditto.live/key-concepts/accessing-data), and
 Ditto syncs those changes when the devices can communicate.
 
-PencilKit represents a canvas as one `PKDrawing` designed for a single editing
-session. Collaborative drawing needs conflict resolution below the complete
-drawing, so DrawTogether uses the individual stroke as that boundary.
+DrawTogether started as a just-for-fun side project and got a lot more involved
+once two people could edit the same PencilKit canvas. PencilKit has strong
+single-writer assumptions, while Ditto is built for peers writing independently.
+This repo shows how those models fit together by making the individual stroke
+the conflict boundary.
 
 ## Data model
 
@@ -120,3 +122,5 @@ The observer turns changes in that store back into UI state.
 Copy `.env.example` to `.env`, fill in the Ditto database ID, server URL, and
 playground token, then open `DrawTogether/DrawTogether.xcodeproj`. The build
 generates an ignored `Env.swift` from that local file.
+
+This is open source, so feel free to open an issue or send a PR.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ DrawTogether is a collaborative iOS drawing app built with
 [local Ditto store](https://docs.ditto.live/key-concepts/accessing-data), and
 Ditto syncs those changes when the devices can communicate.
 
-DrawTogether started as a just-for-fun side project and got a lot more involved
-once two people could edit the same PencilKit canvas. PencilKit has strong
-single-writer assumptions, while Ditto is built for peers writing independently.
-This repo shows how those models fit together by making the individual stroke
-the conflict boundary.
+DrawTogether is a just-for-fun side project focused on two people editing the
+same PencilKit canvas at the same time. PencilKit has strong single-writer
+assumptions, while Ditto is built for peers writing independently. The app
+bridges those models by making the individual stroke the conflict boundary.
 
 ## Data model
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Ditto syncs those changes when the devices can communicate.
 
 DrawTogether is a just-for-fun side project focused on two people editing the
 same PencilKit canvas at the same time. PencilKit has strong single-writer
-assumptions, while Ditto is built for peers writing independently. The app
-bridges those models by making the individual stroke the conflict boundary.
+assumptions, while Ditto uses CRDTs to merge concurrent changes
+deterministically. The app bridges those models by making the individual stroke
+the conflict boundary.
 
 ## Data model
 
@@ -32,8 +33,9 @@ and stores each stroke in a map:
 
 `strokes` is an
 [add-wins Ditto map](https://docs.ditto.live/dql/types-and-definitions#map-operations).
-Each key merges independently, so concurrent additions from different peers are
-preserved. The base64 value under each key is a
+Ditto can merge changes to each key without replacing other entries, so
+concurrent additions from different peers are preserved. The base64 value under
+each key is a
 [register](https://docs.ditto.live/dql/types-and-definitions#register-operations),
 which moves the last-write-wins boundary from the whole canvas down to one
 stroke.


### PR DESCRIPTION
Reworks the public README around the data model that adapts PencilKit's single-drawing representation for multiple writers. It explains the stroke-keyed add-wins map, per-stroke LWW registers, bitmap eraser grouping, and the DQL sync flow, with direct links to the relevant Ditto docs. It also consolidates local setup on `.env.example` and tightens source comments to match the implementation.